### PR TITLE
Parsing des données retournées par la commande radar

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -5,15 +5,17 @@
 #include "spaceship.h"
 #include <stdint.h>
 
-#define MAX_RESPONSE_SIZE 1024
+#define MAX_COMMAND_SIZE 100
+#define MAX_SPLIT_COUNT 200
 
 char *move_str(int8_t ship_id, uint16_t angle, uint16_t speed);
 char *fire_str(int8_t ship_id, uint16_t angle);
 char *radar_str(int8_t ship_id);
 
-char **split(const char *str, const char delimiter, uint16_t *count);
-void parse_radar_response(const char *response, Planet **planets,
-                          uint16_t *nb_planets, Spaceship **spaceships,
+void split(char **tokens, const char *str, const char delimiter,
+           uint16_t *count);
+void parse_radar_response(const char *response, Planet *planets,
+                          uint16_t *nb_planets, Spaceship *spaceships,
                           uint16_t *nb_spaceships, uint16_t *x_base,
                           uint16_t *y_base);
 #endif // COMMANDS_H

--- a/include/embedded_commands.h
+++ b/include/embedded_commands.h
@@ -10,12 +10,12 @@ extern uint16_t base_x, base_y;
 uint8_t move(int8_t ship_id, uint16_t angle, uint16_t speed);
 uint8_t move_v_max(int8_t ship_id, uint16_t angle);
 uint8_t fire(int8_t ship_id, uint16_t angle);
-char *radar(int8_t ship_id);
+void radar(char *response, int8_t ship_id);
 
 extern osMutexId_t planets_spceships_mutex_id;
 // parse radar response using mutex
-void parse_radar_response_mutex(const char *response, Planet **planets,
-                                uint16_t *nb_planets, Spaceship **spaceships,
+void parse_radar_response_mutex(const char *response, Planet *planets,
+                                uint16_t *nb_planets, Spaceship *spaceships,
                                 uint16_t *nb_spaceships, uint16_t *x_base,
                                 uint16_t *y_base);
 

--- a/include/planet.h
+++ b/include/planet.h
@@ -13,11 +13,14 @@ struct Planet_t {
 } typedef Planet;
 
 void create_planet(uint16_t planet_id, uint16_t x, uint16_t y, int8_t ship_id,
-                   uint8_t saved, Planet **planets, uint16_t *nb_planets);
-Planet *get_planet(uint16_t planet_id, Planet **planets, uint16_t nb_planets);
+                   uint8_t saved, Planet *planets, uint16_t *nb_planets);
+Planet *get_planet(uint16_t planet_id, Planet *planets, uint16_t nb_planets);
 void set_planet(uint16_t planet_id, uint16_t x, uint16_t y, int8_t ship_id,
-                uint8_t saved, Planet **planets, uint16_t nb_planets);
+                uint8_t saved, Planet *planets, uint16_t nb_planets);
 
-void delete_planet(uint16_t planet_id, Planet **planets, uint16_t *nb_planets);
-void delete_all_planets(Planet **planets, uint16_t *nb_planets);
+void delete_planet(uint16_t planet_id, Planet *planets, uint16_t *nb_planets);
+void delete_all_planets(Planet *planets, uint16_t *nb_planets);
+
+void planet_to_string(char *str, Planet planet);
+void planets_to_string(char *str, Planet *planets, uint16_t nb_planets);
 #endif // PLANET_H

--- a/include/spaceship.h
+++ b/include/spaceship.h
@@ -14,15 +14,19 @@ struct SpaceShip_t {
 } typedef Spaceship;
 
 void create_spaceship(uint8_t team_id, int8_t ship_id, uint16_t x, uint16_t y,
-                      uint8_t broken, Spaceship **spaceships,
+                      uint8_t broken, Spaceship *spaceships,
                       uint16_t *nb_spaceships);
-Spaceship *get_spaceship(uint8_t team_id, int8_t ship_id,
-                         Spaceship **spaceships, uint16_t nb_spaceships);
+Spaceship *get_spaceship(uint8_t team_id, int8_t ship_id, Spaceship *spaceships,
+                         uint16_t nb_spaceships);
 void set_spaceship(uint8_t team_id, int8_t ship_id, uint16_t x, uint16_t y,
-                   uint8_t broken, Spaceship **spaceships,
+                   uint8_t broken, Spaceship *spaceships,
                    uint16_t nb_spaceships);
 
-void delete_spaceship(uint8_t team_id, int8_t ship_id, Spaceship **spaceships,
+void delete_spaceship(uint8_t team_id, int8_t ship_id, Spaceship *spaceships,
                       uint16_t *nb_spaceships);
-void delete_all_spaceships(Spaceship **spaceships, uint16_t *nb_spaceships);
+void delete_all_spaceships(Spaceship *spaceships, uint16_t *nb_spaceships);
+
+void spaceship_to_string(char *str, Spaceship spaceship);
+void spaceships_to_string(char *str, Spaceship *spaceships,
+                          uint16_t nb_spaceships);
 #endif // SPACESHIP_H

--- a/src/embedded/embedded_commands.c
+++ b/src/embedded/embedded_commands.c
@@ -58,17 +58,15 @@ uint8_t fire(int8_t ship_id, uint16_t angle) {
   return 0;
 }
 
-char *radar(int8_t ship_id) {
-  char *response = malloc(sizeof(char) * MAX_RESPONSE_SIZE);
+void radar(char *response, int8_t ship_id) {
   get_mutex(serial_mutex_id);
   puts(radar_str(ship_id));
   gets(response);
   release_mutex(serial_mutex_id);
-  return response;
 }
 
-void parse_radar_response_mutex(const char *response, Planet **planets,
-                                uint16_t *nb_planets, Spaceship **spaceships,
+void parse_radar_response_mutex(const char *response, Planet *planets,
+                                uint16_t *nb_planets, Spaceship *spaceships,
                                 uint16_t *nb_spaceships, uint16_t *x_base,
                                 uint16_t *y_base) {
   get_mutex(planets_spceships_mutex_id);

--- a/src/main.c
+++ b/src/main.c
@@ -47,7 +47,7 @@ void explorerTask(void *argument) {
     char *radar_response = radar(explorer_id);
     parse_radar_response_mutex(radar_response, planets, &nb_planets, spaceships,
                                &nb_spaceships, &x_base, &y_base);
-    osDelay(1000);
+    osDelay(2000);
   }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -5,7 +5,7 @@
 #include "os_utils.h"
 #include <stdlib.h>
 
-#define DEBUG_SERIAL 1
+// #define DEBUG_SERIAL 1
 
 #define MAX_RESPONSE_SIZE 1024
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,13 +1,11 @@
-#include <math.h>
-#ifndef M_PI
-#define M_PI (3.14159265358979323846)
-#endif
+#include "main.h"
 #include "embedded_commands.h"
 #include "functionCalculs.h"
 #include "gameConstants.h"
-#include "main.h"
 #include "os_utils.h"
 #include <stdlib.h>
+
+#define DEBUG_SERIAL 1
 
 #define MAX_RESPONSE_SIZE 1024
 
@@ -41,14 +39,11 @@ struct collector_follow_args {
 } typedef collector_follow_args;
 
 // explorers
-// get as argument the collector id to follow and his id
 void explorerTask(void *argument) {
-  collector_follow_args *args = (collector_follow_args *)argument;
-  int8_t collector_id = args->collector_id;
-  int8_t explorer_id = args->id;
+  Spaceship *explorer = (Spaceship *)argument;
   char radar_response[MAX_RESPONSE_SIZE];
   while (1) {
-    radar(radar_response, explorer_id);
+    radar(radar_response, explorer->ship_id);
     parse_radar_response_mutex(radar_response, planets, &nb_planets, spaceships,
                                &nb_spaceships, &x_base, &y_base);
     // TODO : emit refresh signal for threads
@@ -65,9 +60,8 @@ void collectorsTask(void *argument) {
 }
 
 // attackers
-// get as argument his id
 void attackerTask(void *argument) {
-  int8_t attacker_id = *(int8_t *)argument;
+  Spaceship *attacker = (Spaceship *)argument;
   while (1) {
     osDelay(1000);
   }
@@ -75,25 +69,22 @@ void attackerTask(void *argument) {
 
 // get as argument the collector id to follow
 void defenderTask(void *argument) {
-  collector_follow_args *args = (collector_follow_args *)argument;
-  int8_t collector_id = args->collector_id;
-  int8_t defender_id = args->id;
+  Spaceship *defender = (Spaceship *)argument;
   while (1) {
     osDelay(1000);
   }
 }
 
 // base defender
-// get as argument his id
 void baseDefenderTask(void *argument) {
-  int8_t base_defender_id = *(int8_t *)argument;
+  Spaceship *base_defender = (Spaceship *)argument;
   uint32_t startTime = osKernelGetTickCount(); // Temps de départ
   int direction = 1; // 1 pour avancer, -1 pour reculer
   int isVerticalMovementComplete =
       0; // 0 pour mouvement vertical en cours, 1 pour terminé
 
   while (1) {
-    fire(base_defender_id, 90);
+    fire(base_defender->ship_id, 90);
 
     uint32_t elapsedTime = osKernelGetTickCount() - startTime;
 
@@ -101,7 +92,7 @@ void baseDefenderTask(void *argument) {
       if (elapsedTime < 2500) { // Durée du mouvement vertical en millisecondes
                                 // (par exemple, 5000 pour 5 secondes)
         move(
-            base_defender_id, 90,
+            base_defender->ship_id, 90,
             1000); // Déplacer verticalement (exemple : angle 90, durée 1000 ms)
       } else {
         isVerticalMovementComplete = 1; // Le mouvement vertical est terminé
@@ -112,9 +103,9 @@ void baseDefenderTask(void *argument) {
           10000) { // Temps total du parcours horizontal en millisecondes (par
                    // exemple, 10000 pour 10 secondes)
         if (direction == 1) {
-          move(base_defender_id, 0, 2000); // Avancer
+          move(base_defender->ship_id, 0, 2000); // Avancer
         } else {
-          move(base_defender_id, 180, 2000); // Reculer
+          move(base_defender->ship_id, 180, 2000); // Reculer
         }
       } else {
         startTime = osKernelGetTickCount(); // Réinitialiser le temps de départ
@@ -134,24 +125,34 @@ int main(void) {
 
   serial_mutex_id = create_mutex(&serial_mutex_attr);
   planets_spceships_mutex_id = create_mutex(&planets_spceships_mutex_attr);
-
+#ifdef DEBUG_SERIAL
+  while (!push_button_is_pressed()) {
+    // Wait for the user to press the button to start the program
+    osDelay(1000);
+  }
+#else
   gets(NULL); // wait the START message
-
+#endif
+  // first scan
+  char radar_response[MAX_RESPONSE_SIZE];
+  radar(radar_response, 6);
+  parse_radar_response_mutex(radar_response, planets, &nb_planets, spaceships,
+                             &nb_spaceships, &x_base, &y_base);
   // explorers threads
   const osThreadAttr_t explorersTask_attributes = {
       .name = "explorersTask",
       .priority = (osPriority_t)osPriorityHigh,
       .stack_size = 2048,
   };
-  collector_follow_args explorer1_args = {8, 6};
-  collector_follow_args explorer2_args = {9, 7};
 
-  if ((explorer1TaskHandle = osThreadNew(explorerTask, &explorer1_args,
-                                         &explorersTask_attributes)) == NULL) {
+  if ((explorer1TaskHandle = osThreadNew(
+           explorerTask, get_spaceship(0, 6, spaceships, nb_spaceships),
+           &explorersTask_attributes)) == NULL) {
     puts("Erreur lors de la création de la tache du premier explorer\n");
   }
-  if ((explorer2TaskHandle = osThreadNew(explorerTask, &explorer2_args,
-                                         &explorersTask_attributes)) == NULL) {
+  if ((explorer2TaskHandle = osThreadNew(
+           explorerTask, get_spaceship(0, 7, spaceships, nb_spaceships),
+           &explorersTask_attributes)) == NULL) {
     puts("Erreur lors de la création de la tache du deuxième explorer\n");
   }
   // collectors threads
@@ -170,32 +171,31 @@ int main(void) {
       .priority = (osPriority_t)osPriorityAboveNormal,
       .stack_size = 1024,
   };
-  int8_t attacker1_id = 1;
-  int8_t attacker2_id = 2;
-  int8_t base_defender_id = 3;
-  if ((attacker1TaskHandle = osThreadNew(attackerTask, &attacker1_id,
-                                         &attackersTask_attributes)) == NULL) {
-    puts("Erreur lors de la création de la tache des attaquants\n");
+  if ((attacker1TaskHandle = osThreadNew(
+           attackerTask, get_spaceship(0, 1, spaceships, nb_spaceships),
+           &attackersTask_attributes)) == NULL) {
+    // Erreur lors de la création de la tache des attaquants\n");
   }
-  if ((attacker2TaskHandle = osThreadNew(attackerTask, &attacker2_id,
-                                         &attackersTask_attributes)) == NULL) {
-    puts("Erreur lors de la création de la tache des attaquants\n");
+  if ((attacker2TaskHandle = osThreadNew(
+           attackerTask, get_spaceship(0, 2, spaceships, nb_spaceships),
+           &attackersTask_attributes)) == NULL) {
+    // Erreur lors de la création de la tache des attaquants
   }
 
-  if ((baseDefenderTaskHandle = osThreadNew(baseDefenderTask, &base_defender_id,
-                                            &attackersTask_attributes)) ==
-      NULL) {
-    puts("Erreur lors de la création de la tache du défenseur de base\n");
+  if ((baseDefenderTaskHandle = osThreadNew(
+           baseDefenderTask, get_spaceship(0, 3, spaceships, nb_spaceships),
+           &attackersTask_attributes)) == NULL) {
+    // Erreur lors de la création de la tache du défenseur de base
   }
-  collector_follow_args defender1_args = {8, 4};
-  collector_follow_args defender2_args = {9, 5};
-  if ((defender1TaskHandle = osThreadNew(defenderTask, &defender1_args,
-                                         &attackersTask_attributes)) == NULL) {
-    puts("Erreur lors de la création de la tache du premier défenseur\n");
+  if ((defender1TaskHandle = osThreadNew(
+           defenderTask, get_spaceship(0, 4, spaceships, nb_spaceships),
+           &attackersTask_attributes)) == NULL) {
+    // Erreur lors de la création de la tache du premier défenseur
   }
-  if ((defender2TaskHandle = osThreadNew(defenderTask, &defender2_args,
-                                         &attackersTask_attributes)) == NULL) {
-    puts("Erreur lors de la création de la tache du deuxième défenseur\n");
+  if ((defender2TaskHandle = osThreadNew(
+           defenderTask, get_spaceship(0, 5, spaceships, nb_spaceships),
+           &attackersTask_attributes)) == NULL) {
+    // Erreur lors de la création de la tache du deuxième défenseur
   }
 
   // démarrage du noyau

--- a/src/planet.c
+++ b/src/planet.c
@@ -38,14 +38,11 @@ void set_planet(uint16_t planet_id, uint16_t x, uint16_t y, int8_t ship_id,
 void delete_planet(uint16_t planet_id, Planet *planets, uint16_t *nb_planets) {
   for (uint16_t i = 0; i < *nb_planets; i++) {
     if (planets[i].planet_id == planet_id) {
-      for (uint16_t j = i; j < *nb_planets - 1; j++) {
-        planets[j] = planets[j + 1];
-      }
-      planets[*nb_planets].planet_id = 0;
-      planets[*nb_planets].x = 0;
-      planets[*nb_planets].y = 0;
-      planets[*nb_planets].ship_id = 0;
-      planets[*nb_planets].saved = 0;
+      planets[i].planet_id = 0;
+      planets[i].x = 0;
+      planets[i].y = 0;
+      planets[i].ship_id = 0;
+      planets[i].saved = 0;
       (*nb_planets)--;
       break;
     }

--- a/src/planet.c
+++ b/src/planet.c
@@ -1,32 +1,31 @@
 #include "planet.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 void create_planet(uint16_t planet_id, uint16_t x, uint16_t y, int8_t ship_id,
-                   uint8_t saved, Planet **planets, uint16_t *nb_planets) {
-  Planet *new_planet = malloc(sizeof(Planet));
-  if (new_planet == NULL)
-    return;
-  new_planet->planet_id = planet_id;
-  new_planet->x = x;
-  new_planet->y = y;
-  new_planet->ship_id = ship_id;
-  new_planet->saved = saved;
+                   uint8_t saved, Planet *planets, uint16_t *nb_planets) {
+  Planet new_planet;
+  new_planet.planet_id = planet_id;
+  new_planet.x = x;
+  new_planet.y = y;
+  new_planet.ship_id = ship_id;
+  new_planet.saved = saved;
   planets[*nb_planets] = new_planet;
   (*nb_planets)++;
 }
 
-Planet *get_planet(uint16_t planet_id, Planet **planets, uint16_t nb_planets) {
+Planet *get_planet(uint16_t planet_id, Planet *planets, uint16_t nb_planets) {
   for (uint16_t i = 0; i < nb_planets; i++) {
-    if (planets[i]->planet_id == planet_id) {
-      return planets[i];
+    if (planets[i].planet_id == planet_id) {
+      return &planets[i];
     }
   }
   return NULL;
 }
 
 void set_planet(uint16_t planet_id, uint16_t x, uint16_t y, int8_t ship_id,
-                uint8_t saved, Planet **planets, uint16_t nb_planets) {
+                uint8_t saved, Planet *planets, uint16_t nb_planets) {
   Planet *planet = get_planet(planet_id, planets, nb_planets);
   if (planet == NULL)
     return;
@@ -36,22 +35,43 @@ void set_planet(uint16_t planet_id, uint16_t x, uint16_t y, int8_t ship_id,
   planet->saved = saved;
 }
 
-void delete_planet(uint16_t planet_id, Planet **planets, uint16_t *nb_planets) {
+void delete_planet(uint16_t planet_id, Planet *planets, uint16_t *nb_planets) {
   for (uint16_t i = 0; i < *nb_planets; i++) {
-    if (planets[i]->planet_id == planet_id) {
-      free(planets[i]);
+    if (planets[i].planet_id == planet_id) {
       for (uint16_t j = i; j < *nb_planets - 1; j++) {
         planets[j] = planets[j + 1];
       }
+      planets[*nb_planets].planet_id = 0;
+      planets[*nb_planets].x = 0;
+      planets[*nb_planets].y = 0;
+      planets[*nb_planets].ship_id = 0;
+      planets[*nb_planets].saved = 0;
       (*nb_planets)--;
       break;
     }
   }
 }
 
-void delete_all_planets(Planet **planets, uint16_t *nb_planets) {
+void delete_all_planets(Planet *planets, uint16_t *nb_planets) {
   for (uint16_t i = 0; i < *nb_planets; i++) {
-    free(planets[i]);
+    planets[i].planet_id = 0;
+    planets[i].x = 0;
+    planets[i].y = 0;
+    planets[i].ship_id = 0;
+    planets[i].saved = 0;
   }
   *nb_planets = 0;
+}
+
+void planet_to_string(char *str, Planet planet) {
+  sprintf(str, "Planet %d: x=%d, y=%d, ship_id=%d, saved=%d", planet.planet_id,
+          planet.x, planet.y, planet.ship_id, planet.saved);
+}
+void planets_to_string(char *str, Planet *planets, uint16_t nb_planets) {
+  for (uint16_t i = 0; i < nb_planets; i++) {
+    char planet_str[100];
+    planet_to_string(planet_str, planets[i]);
+    strcat(str, planet_str);
+    strcat(str, "\n");
+  }
 }

--- a/src/spaceship.c
+++ b/src/spaceship.c
@@ -1,32 +1,33 @@
 #include "spaceship.h"
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 void create_spaceship(uint8_t team_id, int8_t ship_id, uint16_t x, uint16_t y,
-                      uint8_t broken, Spaceship **spaceships,
+                      uint8_t broken, Spaceship *spaceships,
                       uint16_t *nb_spaceships) {
-  Spaceship *new_spaceship = malloc(sizeof(Spaceship));
-  new_spaceship->team_id = team_id;
-  new_spaceship->ship_id = ship_id;
-  new_spaceship->x = x;
-  new_spaceship->y = y;
-  new_spaceship->broken = broken;
+  Spaceship new_spaceship;
+  new_spaceship.team_id = team_id;
+  new_spaceship.ship_id = ship_id;
+  new_spaceship.x = x;
+  new_spaceship.y = y;
+  new_spaceship.broken = broken;
   spaceships[*nb_spaceships] = new_spaceship;
   (*nb_spaceships)++;
 }
 
-Spaceship *get_spaceship(uint8_t team_id, int8_t ship_id,
-                         Spaceship **spaceships, uint16_t nb_spaceships) {
+Spaceship *get_spaceship(uint8_t team_id, int8_t ship_id, Spaceship *spaceships,
+                         uint16_t nb_spaceships) {
   for (uint16_t i = 0; i < nb_spaceships; i++) {
-    if (spaceships[i]->team_id == team_id &&
-        spaceships[i]->ship_id == ship_id) {
-      return spaceships[i];
+    if (spaceships[i].team_id == team_id && spaceships[i].ship_id == ship_id) {
+      return &spaceships[i];
     }
   }
   return NULL;
 }
 
 void set_spaceship(uint8_t team_id, int8_t ship_id, uint16_t x, uint16_t y,
-                   uint8_t broken, Spaceship **spaceships,
+                   uint8_t broken, Spaceship *spaceships,
                    uint16_t nb_spaceships) {
   Spaceship *spaceship =
       get_spaceship(team_id, ship_id, spaceships, nb_spaceships);
@@ -37,24 +38,46 @@ void set_spaceship(uint8_t team_id, int8_t ship_id, uint16_t x, uint16_t y,
   spaceship->broken = broken;
 }
 
-void delete_spaceship(uint8_t team_id, int8_t ship_id, Spaceship **spaceships,
+void delete_spaceship(uint8_t team_id, int8_t ship_id, Spaceship *spaceships,
                       uint16_t *nb_spaceships) {
   for (uint16_t i = 0; i < *nb_spaceships; i++) {
-    if (spaceships[i]->team_id == team_id &&
-        spaceships[i]->ship_id == ship_id) {
-      free(spaceships[i]);
+    if (spaceships[i].team_id == team_id && spaceships[i].ship_id == ship_id) {
       for (uint16_t j = i; j < *nb_spaceships - 1; j++) {
         spaceships[j] = spaceships[j + 1];
       }
+      spaceships[*nb_spaceships].team_id = 0;
+      spaceships[*nb_spaceships].ship_id = 0;
+      spaceships[*nb_spaceships].x = 0;
+      spaceships[*nb_spaceships].y = 0;
+      spaceships[*nb_spaceships].broken = 0;
       (*nb_spaceships)--;
       break;
     }
   }
 }
 
-void delete_all_spaceships(Spaceship **spaceships, uint16_t *nb_spaceships) {
+void delete_all_spaceships(Spaceship *spaceships, uint16_t *nb_spaceships) {
   for (uint16_t i = 0; i < *nb_spaceships; i++) {
-    free(spaceships[i]);
+    spaceships[i].team_id = 0;
+    spaceships[i].ship_id = 0;
+    spaceships[i].x = 0;
+    spaceships[i].y = 0;
+    spaceships[i].broken = 0;
   }
   *nb_spaceships = 0;
+}
+
+void spaceship_to_string(char *str, Spaceship spaceship) {
+  sprintf(str, "Spaceship %d: x=%d, y=%d, broken=%d", spaceship.ship_id,
+          spaceship.x, spaceship.y, spaceship.broken);
+}
+
+void spaceships_to_string(char *str, Spaceship *spaceships,
+                          uint16_t nb_spaceships) {
+  for (uint16_t i = 0; i < nb_spaceships; i++) {
+    char spaceship_str[100];
+    spaceship_to_string(spaceship_str, spaceships[i]);
+    strcat(str, spaceship_str);
+    strcat(str, "\n");
+  }
 }

--- a/src/spaceship.c
+++ b/src/spaceship.c
@@ -42,14 +42,11 @@ void delete_spaceship(uint8_t team_id, int8_t ship_id, Spaceship *spaceships,
                       uint16_t *nb_spaceships) {
   for (uint16_t i = 0; i < *nb_spaceships; i++) {
     if (spaceships[i].team_id == team_id && spaceships[i].ship_id == ship_id) {
-      for (uint16_t j = i; j < *nb_spaceships - 1; j++) {
-        spaceships[j] = spaceships[j + 1];
-      }
-      spaceships[*nb_spaceships].team_id = 0;
-      spaceships[*nb_spaceships].ship_id = 0;
-      spaceships[*nb_spaceships].x = 0;
-      spaceships[*nb_spaceships].y = 0;
-      spaceships[*nb_spaceships].broken = 0;
+      spaceships[i].team_id = 0;
+      spaceships[i].ship_id = 0;
+      spaceships[i].x = 0;
+      spaceships[i].y = 0;
+      spaceships[i].broken = 0;
       (*nb_spaceships)--;
       break;
     }

--- a/test/desktop/test_commands/test_commands.c
+++ b/test/desktop/test_commands/test_commands.c
@@ -40,19 +40,19 @@ void test_radar_command(void) {
 
 void test_split(void) {
   uint16_t count;
-  char **tokens = split("Theo,Louis,Pachelle Carelle", ',', &count);
+  char *tokens[MAX_SPLIT_COUNT];
+  split(tokens, "Theo,Louis,Pachelle Carelle", ',', &count);
   TEST_ASSERT_EQUAL(3, count);
   TEST_ASSERT_EQUAL_STRING("Theo", tokens[0]);
   TEST_ASSERT_EQUAL_STRING("Louis", tokens[1]);
   TEST_ASSERT_EQUAL_STRING("Pachelle Carelle", tokens[2]);
-  free(tokens);
 }
 
 void test_parse_radar_response(void) {
   // Arrange
-  Planet *planets[NB_MAX_PLANETS];
+  Planet planets[NB_MAX_PLANETS];
   uint16_t nb_planets = 0;
-  Spaceship *spaceships[NB_MAX_SPACESHIPS];
+  Spaceship spaceships[NB_MAX_SPACESHIPS];
   uint16_t nb_spaceships = 0;
   uint16_t x_base = 0;
   uint16_t y_base = 0;
@@ -67,16 +67,16 @@ void test_parse_radar_response(void) {
   TEST_ASSERT_EQUAL(10000, x_base);
   TEST_ASSERT_EQUAL(2000, y_base);
   for (uint16_t i = 0; i < 5; i++) {
-    TEST_ASSERT_EQUAL(i, planets[i]->planet_id);
-    TEST_ASSERT_EQUAL(i + 1, planets[i]->x);
-    TEST_ASSERT_EQUAL(i + 2, planets[i]->y);
-    TEST_ASSERT_EQUAL(i + 3, planets[i]->ship_id);
-    TEST_ASSERT_EQUAL(i % 2, planets[i]->saved);
+    TEST_ASSERT_EQUAL(i, planets[i].planet_id);
+    TEST_ASSERT_EQUAL(i + 1, planets[i].x);
+    TEST_ASSERT_EQUAL(i + 2, planets[i].y);
+    TEST_ASSERT_EQUAL(i + 3, planets[i].ship_id);
+    TEST_ASSERT_EQUAL(i % 2, planets[i].saved);
 
-    TEST_ASSERT_EQUAL(i, spaceships[i]->team_id);
-    TEST_ASSERT_EQUAL(i + 1, spaceships[i]->ship_id);
-    TEST_ASSERT_EQUAL(i + 2, spaceships[i]->x);
-    TEST_ASSERT_EQUAL(i % 2, spaceships[i]->broken);
+    TEST_ASSERT_EQUAL(i, spaceships[i].team_id);
+    TEST_ASSERT_EQUAL(i + 1, spaceships[i].ship_id);
+    TEST_ASSERT_EQUAL(i + 2, spaceships[i].x);
+    TEST_ASSERT_EQUAL(i % 2, spaceships[i].broken);
   }
   delete_all_planets(planets, &nb_planets);
   delete_all_spaceships(spaceships, &nb_spaceships);

--- a/test/desktop/test_planet/test_planet.c
+++ b/test/desktop/test_planet/test_planet.c
@@ -89,11 +89,16 @@ void test_delete_planet(void) {
   delete_planet(352, planets, &nb_planets);
   // Assert
   TEST_ASSERT_EQUAL(2, nb_planets);
-  TEST_ASSERT_EQUAL(426, planets[0].planet_id);
-  TEST_ASSERT_EQUAL(9000, planets[0].x);
-  TEST_ASSERT_EQUAL(11000, planets[0].y);
-  TEST_ASSERT_EQUAL(-1, planets[0].ship_id);
+  TEST_ASSERT_EQUAL(0, planets[0].planet_id);
+  TEST_ASSERT_EQUAL(0, planets[0].x);
+  TEST_ASSERT_EQUAL(0, planets[0].y);
+  TEST_ASSERT_EQUAL(0, planets[0].ship_id);
   TEST_ASSERT_EQUAL(0, planets[0].saved);
+  TEST_ASSERT_EQUAL(426, planets[1].planet_id);
+  TEST_ASSERT_EQUAL(9000, planets[1].x);
+  TEST_ASSERT_EQUAL(11000, planets[1].y);
+  TEST_ASSERT_EQUAL(-1, planets[1].ship_id);
+  TEST_ASSERT_EQUAL(0, planets[1].saved);
 }
 
 void test_delete_all_planets(void) {

--- a/test/desktop/test_planet/test_planet.c
+++ b/test/desktop/test_planet/test_planet.c
@@ -2,7 +2,7 @@
 #include "unity.h"
 #include <stdio.h>
 
-Planet *planets[NB_MAX_PLANETS];
+Planet planets[NB_MAX_PLANETS];
 uint16_t nb_planets = 0;
 
 void setUp(void) {
@@ -13,7 +13,7 @@ void setUp(void) {
 }
 
 void tearDown(void) {
-  // clean planets allocation
+  // clean planets
   delete_all_planets(planets, &nb_planets);
 }
 
@@ -28,11 +28,11 @@ void test_create_planet(void) {
   create_planet(planet_id, x, y, ship_id, saved, planets, &nb_planets);
   // Assert
   TEST_ASSERT_EQUAL(4, nb_planets);
-  TEST_ASSERT_EQUAL(planet_id, planets[nb_planets - 1]->planet_id);
-  TEST_ASSERT_EQUAL(x, planets[nb_planets - 1]->x);
-  TEST_ASSERT_EQUAL(y, planets[nb_planets - 1]->y);
-  TEST_ASSERT_EQUAL(ship_id, planets[nb_planets - 1]->ship_id);
-  TEST_ASSERT_EQUAL(saved, planets[nb_planets - 1]->saved);
+  TEST_ASSERT_EQUAL(planet_id, planets[nb_planets - 1].planet_id);
+  TEST_ASSERT_EQUAL(x, planets[nb_planets - 1].x);
+  TEST_ASSERT_EQUAL(y, planets[nb_planets - 1].y);
+  TEST_ASSERT_EQUAL(ship_id, planets[nb_planets - 1].ship_id);
+  TEST_ASSERT_EQUAL(saved, planets[nb_planets - 1].saved);
 }
 
 void test_get_planet_null(void) {
@@ -60,16 +60,16 @@ void test_set_bad_planet(void) {
   set_planet(500, 8000, 10000, 6, 1, planets, nb_planets);
   // Assert
   TEST_ASSERT_EQUAL(3, nb_planets);
-  TEST_ASSERT_EQUAL(352, planets[0]->planet_id);
-  TEST_ASSERT_EQUAL(10000, planets[0]->x);
-  TEST_ASSERT_EQUAL(11200, planets[0]->y);
-  TEST_ASSERT_EQUAL(3, planets[0]->ship_id);
-  TEST_ASSERT_EQUAL(0, planets[0]->saved);
-  TEST_ASSERT_EQUAL(426, planets[1]->planet_id);
-  TEST_ASSERT_EQUAL(9000, planets[1]->x);
-  TEST_ASSERT_EQUAL(11000, planets[1]->y);
-  TEST_ASSERT_EQUAL(-1, planets[1]->ship_id);
-  TEST_ASSERT_EQUAL(0, planets[1]->saved);
+  TEST_ASSERT_EQUAL(352, planets[0].planet_id);
+  TEST_ASSERT_EQUAL(10000, planets[0].x);
+  TEST_ASSERT_EQUAL(11200, planets[0].y);
+  TEST_ASSERT_EQUAL(3, planets[0].ship_id);
+  TEST_ASSERT_EQUAL(0, planets[0].saved);
+  TEST_ASSERT_EQUAL(426, planets[1].planet_id);
+  TEST_ASSERT_EQUAL(9000, planets[1].x);
+  TEST_ASSERT_EQUAL(11000, planets[1].y);
+  TEST_ASSERT_EQUAL(-1, planets[1].ship_id);
+  TEST_ASSERT_EQUAL(0, planets[1].saved);
 }
 
 void test_set_planet(void) {
@@ -77,11 +77,11 @@ void test_set_planet(void) {
   set_planet(426, 9500, 12000, 2, 1, planets, nb_planets);
   // Assert
   TEST_ASSERT_EQUAL(3, nb_planets);
-  TEST_ASSERT_EQUAL(426, planets[1]->planet_id);
-  TEST_ASSERT_EQUAL(9500, planets[1]->x);
-  TEST_ASSERT_EQUAL(12000, planets[1]->y);
-  TEST_ASSERT_EQUAL(2, planets[1]->ship_id);
-  TEST_ASSERT_EQUAL(1, planets[1]->saved);
+  TEST_ASSERT_EQUAL(426, planets[1].planet_id);
+  TEST_ASSERT_EQUAL(9500, planets[1].x);
+  TEST_ASSERT_EQUAL(12000, planets[1].y);
+  TEST_ASSERT_EQUAL(2, planets[1].ship_id);
+  TEST_ASSERT_EQUAL(1, planets[1].saved);
 }
 
 void test_delete_planet(void) {
@@ -89,11 +89,11 @@ void test_delete_planet(void) {
   delete_planet(352, planets, &nb_planets);
   // Assert
   TEST_ASSERT_EQUAL(2, nb_planets);
-  TEST_ASSERT_EQUAL(426, planets[0]->planet_id);
-  TEST_ASSERT_EQUAL(9000, planets[0]->x);
-  TEST_ASSERT_EQUAL(11000, planets[0]->y);
-  TEST_ASSERT_EQUAL(-1, planets[0]->ship_id);
-  TEST_ASSERT_EQUAL(0, planets[0]->saved);
+  TEST_ASSERT_EQUAL(426, planets[0].planet_id);
+  TEST_ASSERT_EQUAL(9000, planets[0].x);
+  TEST_ASSERT_EQUAL(11000, planets[0].y);
+  TEST_ASSERT_EQUAL(-1, planets[0].ship_id);
+  TEST_ASSERT_EQUAL(0, planets[0].saved);
 }
 
 void test_delete_all_planets(void) {

--- a/test/desktop/test_spaceship/test_spaceship.c
+++ b/test/desktop/test_spaceship/test_spaceship.c
@@ -2,7 +2,7 @@
 #include "unity.h"
 #include <stdlib.h>
 
-Spaceship *spaceships[NB_MAX_SPACESHIPS];
+Spaceship spaceships[NB_MAX_SPACESHIPS];
 uint16_t nb_spaceships = 0;
 
 void setUp(void) {
@@ -28,11 +28,11 @@ void test_create_spaceship(void) {
   create_spaceship(team_id, ship_id, x, y, broken, spaceships, &nb_spaceships);
   // Assert
   TEST_ASSERT_EQUAL(4, nb_spaceships);
-  TEST_ASSERT_EQUAL(team_id, spaceships[nb_spaceships - 1]->team_id);
-  TEST_ASSERT_EQUAL(ship_id, spaceships[nb_spaceships - 1]->ship_id);
-  TEST_ASSERT_EQUAL(x, spaceships[nb_spaceships - 1]->x);
-  TEST_ASSERT_EQUAL(y, spaceships[nb_spaceships - 1]->y);
-  TEST_ASSERT_EQUAL(broken, spaceships[nb_spaceships - 1]->broken);
+  TEST_ASSERT_EQUAL(team_id, spaceships[nb_spaceships - 1].team_id);
+  TEST_ASSERT_EQUAL(ship_id, spaceships[nb_spaceships - 1].ship_id);
+  TEST_ASSERT_EQUAL(x, spaceships[nb_spaceships - 1].x);
+  TEST_ASSERT_EQUAL(y, spaceships[nb_spaceships - 1].y);
+  TEST_ASSERT_EQUAL(broken, spaceships[nb_spaceships - 1].broken);
 }
 
 void test_get_spaceship_null(void) {
@@ -82,16 +82,16 @@ void test_delete_spaceship(void) {
   delete_spaceship(2, 4, spaceships, &nb_spaceships);
   // Assert
   TEST_ASSERT_EQUAL(2, nb_spaceships);
-  TEST_ASSERT_EQUAL(1, spaceships[0]->team_id);
-  TEST_ASSERT_EQUAL(3, spaceships[0]->ship_id);
-  TEST_ASSERT_EQUAL(10000, spaceships[0]->x);
-  TEST_ASSERT_EQUAL(11200, spaceships[0]->y);
-  TEST_ASSERT_EQUAL(1, spaceships[0]->broken);
-  TEST_ASSERT_EQUAL(3, spaceships[1]->team_id);
-  TEST_ASSERT_EQUAL(5, spaceships[1]->ship_id);
-  TEST_ASSERT_EQUAL(8000, spaceships[1]->x);
-  TEST_ASSERT_EQUAL(10000, spaceships[1]->y);
-  TEST_ASSERT_EQUAL(1, spaceships[1]->broken);
+  TEST_ASSERT_EQUAL(1, spaceships[0].team_id);
+  TEST_ASSERT_EQUAL(3, spaceships[0].ship_id);
+  TEST_ASSERT_EQUAL(10000, spaceships[0].x);
+  TEST_ASSERT_EQUAL(11200, spaceships[0].y);
+  TEST_ASSERT_EQUAL(1, spaceships[0].broken);
+  TEST_ASSERT_EQUAL(3, spaceships[1].team_id);
+  TEST_ASSERT_EQUAL(5, spaceships[1].ship_id);
+  TEST_ASSERT_EQUAL(8000, spaceships[1].x);
+  TEST_ASSERT_EQUAL(10000, spaceships[1].y);
+  TEST_ASSERT_EQUAL(1, spaceships[1].broken);
 }
 
 void test_delete_all_spaceships(void) {

--- a/test/desktop/test_spaceship/test_spaceship.c
+++ b/test/desktop/test_spaceship/test_spaceship.c
@@ -87,11 +87,11 @@ void test_delete_spaceship(void) {
   TEST_ASSERT_EQUAL(10000, spaceships[0].x);
   TEST_ASSERT_EQUAL(11200, spaceships[0].y);
   TEST_ASSERT_EQUAL(1, spaceships[0].broken);
-  TEST_ASSERT_EQUAL(3, spaceships[1].team_id);
-  TEST_ASSERT_EQUAL(5, spaceships[1].ship_id);
-  TEST_ASSERT_EQUAL(8000, spaceships[1].x);
-  TEST_ASSERT_EQUAL(10000, spaceships[1].y);
-  TEST_ASSERT_EQUAL(1, spaceships[1].broken);
+  TEST_ASSERT_EQUAL(0, spaceships[1].team_id);
+  TEST_ASSERT_EQUAL(0, spaceships[1].ship_id);
+  TEST_ASSERT_EQUAL(0, spaceships[1].x);
+  TEST_ASSERT_EQUAL(0, spaceships[1].y);
+  TEST_ASSERT_EQUAL(0, spaceships[1].broken);
 }
 
 void test_delete_all_spaceships(void) {


### PR DESCRIPTION
Changements :
- redéfinition des planètes et vaisseaux (plus de malloc)
- idem pour split, on n'utilise plus strtok qui faisait planter le code une fois lancé dans le thread et on a supprimé les malloc par la même occasion
- Passage de toutes les données des vaisseaux en paramètre des threads via un pointeur sur leur struct
- Pour éviter les décollages de mémoire sur les pointeurs passés aux threads, quand on supprime un vaisseau ou une planète maintenant on ne réinvente plus toute la liste (on ne met plus tous les vaisseaux/planètes "à gauche" dans la liste)
- ajout du mutex pour les planètes et vaisseaux (à retravailler pour faire un mutex par planète/vaisseau)