### PR TITLE
Protéger l'accès aux planètes et vaisseaux en lecture par des mutexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .pio
 unity-app
 
+# logs
+*.log
+
 # VSCode
 .vscode
 

--- a/include/commands.h
+++ b/include/commands.h
@@ -6,7 +6,7 @@
 #include <stdint.h>
 
 #define MAX_COMMAND_SIZE 100
-#define MAX_SPLIT_COUNT 200
+#define NB_MAX_PARAMS 6
 
 char *move_str(int8_t ship_id, uint16_t angle, uint16_t speed);
 char *fire_str(int8_t ship_id, uint16_t angle);

--- a/include/embedded_commands.h
+++ b/include/embedded_commands.h
@@ -12,7 +12,7 @@ uint8_t move_v_max(int8_t ship_id, uint16_t angle);
 uint8_t fire(int8_t ship_id, uint16_t angle);
 void radar(char *response, int8_t ship_id);
 
-extern osMutexId_t planets_spceships_mutex_id;
+extern osMutexId_t planets_spaceships_mutex_id;
 // parse radar response using mutex
 void parse_radar_response_mutex(const char *response, Planet *planets,
                                 uint16_t *nb_planets, Spaceship *spaceships,

--- a/include/embedded_commands.h
+++ b/include/embedded_commands.h
@@ -9,6 +9,8 @@
 extern uint16_t base_x, base_y;
 uint8_t move(int8_t ship_id, uint16_t angle, uint16_t speed);
 uint8_t move_v_max(int8_t ship_id, uint16_t angle);
+uint8_t move_spaceship_to(Spaceship spaceship, uint16_t x, uint16_t y,
+                          uint16_t speed);
 uint8_t fire(int8_t ship_id, uint16_t angle);
 void radar(char *response, int8_t ship_id);
 

--- a/include/embedded_spaceship.h
+++ b/include/embedded_spaceship.h
@@ -7,9 +7,6 @@
 
 extern osMutexId_t planets_spaceships_mutex_id;
 
-const osMutexAttr_t spaceships_mutex_attr = {"spaceshipsMutex",
-                                             osMutexPrioInherit, NULL, 0U};
-
 struct Embedded_spaceship_t {
   Spaceship *spaceship;
   uint8_t index;
@@ -19,7 +16,11 @@ struct Embedded_spaceship_t {
 void init_embedded_spaceship(Embedded_spaceship *embedded_spaceship,
                              Spaceship *spaceship, uint8_t index);
 void init_embedded_spaceships(Embedded_spaceship *embedded_spaceships,
-                              Spaceship *spaceships, uint16_t nb_spaceships);
+                              Spaceship *spaceships);
+
+Embedded_spaceship *
+get_embedded_spaceship(uint8_t team_id, int8_t ship_id,
+                       Embedded_spaceship *embedded_spaceships);
 
 Spaceship get_spaceship_mutex(Embedded_spaceship *embedded_spaceships,
                               uint8_t index);

--- a/include/embedded_spaceship.h
+++ b/include/embedded_spaceship.h
@@ -1,0 +1,30 @@
+#ifndef EMBEDDED_SPACESHIP_H
+#define EMBEDDED_SPACESHIP_H
+
+#include "os_utils.h"
+#include "spaceship.h"
+#include <stdint.h>
+
+extern osMutexId_t planets_spaceships_mutex_id;
+
+const osMutexAttr_t spaceships_mutex_attr = {"spaceshipsMutex",
+                                             osMutexPrioInherit, NULL, 0U};
+
+struct Embedded_spaceship_t {
+  Spaceship *spaceship;
+  uint8_t index;
+  osMutexId_t mutex_id;
+} typedef Embedded_spaceship;
+
+void init_embedded_spaceship(Embedded_spaceship *embedded_spaceship,
+                             Spaceship *spaceship, uint8_t index);
+void init_embedded_spaceships(Embedded_spaceship *embedded_spaceships,
+                              Spaceship *spaceships, uint16_t nb_spaceships);
+
+Spaceship get_spaceship_mutex(Embedded_spaceship *embedded_spaceships,
+                              uint8_t index);
+
+Spaceship update_spaceship_mutex(Spaceship spaceship,
+                                 Embedded_spaceship *embedded_spaceships,
+                                 uint8_t index);
+#endif // EMBEDDED_SPACESHIP_H

--- a/include/planet.h
+++ b/include/planet.h
@@ -14,13 +14,13 @@ struct Planet_t {
 
 void create_planet(uint16_t planet_id, uint16_t x, uint16_t y, int8_t ship_id,
                    uint8_t saved, Planet *planets, uint16_t *nb_planets);
-Planet *get_planet(uint16_t planet_id, Planet *planets, uint16_t nb_planets);
+Planet *get_planet(uint16_t planet_id, Planet *planets);
 void set_planet(uint16_t planet_id, uint16_t x, uint16_t y, int8_t ship_id,
-                uint8_t saved, Planet *planets, uint16_t nb_planets);
+                uint8_t saved, Planet *planets);
 
 void delete_planet(uint16_t planet_id, Planet *planets, uint16_t *nb_planets);
 void delete_all_planets(Planet *planets, uint16_t *nb_planets);
 
 void planet_to_string(char *str, Planet planet);
-void planets_to_string(char *str, Planet *planets, uint16_t nb_planets);
+void planets_to_string(char *str, Planet *planets);
 #endif // PLANET_H

--- a/include/spaceship.h
+++ b/include/spaceship.h
@@ -16,17 +16,15 @@ struct SpaceShip_t {
 void create_spaceship(uint8_t team_id, int8_t ship_id, uint16_t x, uint16_t y,
                       uint8_t broken, Spaceship *spaceships,
                       uint16_t *nb_spaceships);
-Spaceship *get_spaceship(uint8_t team_id, int8_t ship_id, Spaceship *spaceships,
-                         uint16_t nb_spaceships);
+Spaceship *get_spaceship(uint8_t team_id, int8_t ship_id,
+                         Spaceship *spaceships);
 void set_spaceship(uint8_t team_id, int8_t ship_id, uint16_t x, uint16_t y,
-                   uint8_t broken, Spaceship *spaceships,
-                   uint16_t nb_spaceships);
+                   uint8_t broken, Spaceship *spaceships);
 
 void delete_spaceship(uint8_t team_id, int8_t ship_id, Spaceship *spaceships,
                       uint16_t *nb_spaceships);
 void delete_all_spaceships(Spaceship *spaceships, uint16_t *nb_spaceships);
 
 void spaceship_to_string(char *str, Spaceship spaceship);
-void spaceships_to_string(char *str, Spaceship *spaceships,
-                          uint16_t nb_spaceships);
+void spaceships_to_string(char *str, Spaceship *spaceships);
 #endif // SPACESHIP_H

--- a/launchSerialTcp.sh
+++ b/launchSerialTcp.sh
@@ -1,0 +1,6 @@
+ADRESS="192.168.43.152"
+PORT="12346"
+SERIAL="/dev/cu.usbserial-AD0K8WZ8"
+TEAM_NAME="SDF"
+
+python3 -m space_collector.serial2tcp -a $ADRESS -p $PORT --serial $SERIAL --team-name $TEAM_NAME

--- a/notes
+++ b/notes
@@ -70,6 +70,8 @@ Priorisation des taches :
 ------------------------------------------------------------------
 Notes Louis pour le rapport :
 
+Structure du projet et tests unitaires :
+
 1 - Partis sur des tests basiques avec minunit
 2 - Mise en place des pre-commit pour le formattage de code qui amène la réflexion de lancer automatiquement les tests dans le processus de commit/push
 3 - mise en place d'un makefile + script pour build tout les tests du répertoire 'test'
@@ -78,6 +80,18 @@ Notes Louis pour le rapport :
 6 - choix de migrer nos tests et notre façon de faire avec minunit pour écrire nos tests avec 'unity' (framework de test intégré à platformio) pour pouvoir utiliser le workflow découvert
 7 - complications car il a fallu initialiser un environnement 'native' pour pouvoir run nos tests en local sur notre machine + fichiers unity_config pour les tests sur stm32
 8 - build de l'environnement 'native' en erreur à cause des imports FreeRTOS et stm32
-9 - mise en place d'inclusion/exclusion de fichiers pour build juste ce qu'il nous faut pour tester nos fichiers car nos fichiers sont rangés d'une manière qui plaît pas à platformio donc obligé de bidouyer (forcer le runner des tests à comiler les sources)
+9 - mise en place d'inclusion/exclusion de fichiers pour build juste ce qu'il nous faut pour tester nos fichiers car nos fichiers sont rangés d'une manière qui plaît pas à platformio donc obligé de bidouyer (forcer le runner des tests à compiler les sources)
 10 - revue de l'arborescence des tests pour éviter des erreurs de compilation car 2 fichiers de tests dans le meme répertoire de test = 2 fonctions main en même temps pour le compilateur
 11 - implémentation workflow GitHub
+
+Pour le parsing de la réponse du radar :
+Problèmes eus avec strtok et revert fait pour malloc pas necessaire dans notre cas.
+
+Après le premier parsing, initialiser les planetes et vaisseaux avec leurs mutex vu qu'ils ne seront pas supprimés.
+
+Séparation des vaisseaux en 2 listes : vaisseaux alliés et vaisseaux ennemis
+Pourquoi ? Parce qu'on a plus souvent besoin d'accéder aux coordonnées de certains vaisseaux alliés spécifiques donc un mutex par vaisseau alliés. Mais souvent pour les vaisseaux ennemis on parcours la liste de ces vaisseaux pour savoir lequel est à portée de tir donc un mutex pour la liste
+De plus les vaisseaux alliés une fois créés ne seront pas supprimés car toujours présents. Or les vaisseaux ennemis peuvent dans une évolution future être supprimés de la liste si ils ne sont plus détectés.
+
+Finalement non on sait que les 9 premiers indexes de la liste des vaisseaux sont nos vaisseaux car au premier scan aucun des vaisseaux ennemis sont visibles.
+Donc on passera seulement un mutex par vaisseau pour nos vaisseaux alliés. Pour parcourir parmis les vaisseaux ennemis un unique mutex sera utilisé.

--- a/src/commands.c
+++ b/src/commands.c
@@ -51,7 +51,7 @@ void parse_planet(char **params, Planet *planets, uint16_t *nb_planets) {
   uint16_t y = atoi(params[3]);
   int8_t ship_id = atoi(params[4]);
   uint8_t saved = atoi(params[5]);
-  Planet *planet = get_planet(planet_id, planets, *nb_planets);
+  Planet *planet = get_planet(planet_id, planets);
   if (planet == NULL) {
     // If the planet does not exist, create it
     create_planet(planet_id, x, y, ship_id, saved, planets, nb_planets);
@@ -70,8 +70,7 @@ void parse_spaceship(char **params, Spaceship *spaceships,
   uint16_t x = atoi(params[3]);
   uint16_t y = atoi(params[4]);
   uint8_t broken = atoi(params[5]);
-  Spaceship *spaceship =
-      get_spaceship(team_id, ship_id, spaceships, *nb_spaceships);
+  Spaceship *spaceship = get_spaceship(team_id, ship_id, spaceships);
   if (spaceship == NULL) {
     // If the spaceship does not exist, create it
     create_spaceship(team_id, ship_id, x, y, broken, spaceships, nb_spaceships);

--- a/src/commands.c
+++ b/src/commands.c
@@ -45,7 +45,7 @@ void split(char **tokens, const char *str, const char delimiter,
   (*count)++;
 }
 
-void process_planet(char **params, Planet *planets, uint16_t *nb_planets) {
+void parse_planet(char **params, Planet *planets, uint16_t *nb_planets) {
   uint16_t planet_id = atoi(params[1]);
   uint16_t x = atoi(params[2]);
   uint16_t y = atoi(params[3]);
@@ -63,8 +63,8 @@ void process_planet(char **params, Planet *planets, uint16_t *nb_planets) {
   planet->saved = saved;
 }
 
-void process_spaceship(char **params, Spaceship *spaceships,
-                       uint16_t *nb_spaceships) {
+void parse_spaceship(char **params, Spaceship *spaceships,
+                     uint16_t *nb_spaceships) {
   uint8_t team_id = atoi(params[1]);
   int8_t ship_id = atoi(params[2]);
   uint16_t x = atoi(params[3]);
@@ -95,9 +95,9 @@ void parse_radar_response(const char *response, Planet *planets,
     char *params[MAX_SPLIT_COUNT];
     split(params, str_scan[i], ' ', &nb_params);
     if (params[0][0] == PLANET) {
-      process_planet(params, planets, nb_planets);
+      parse_planet(params, planets, nb_planets);
     } else if (params[0][0] == SPACESHIP) {
-      process_spaceship(params, spaceships, nb_spaceships);
+      parse_spaceship(params, spaceships, nb_spaceships);
     } else if (params[0][0] == BASE) {
       *x_base = atoi(params[1]);
       *y_base = atoi(params[2]);

--- a/src/commands.c
+++ b/src/commands.c
@@ -87,11 +87,11 @@ void parse_radar_response(const char *response, Planet *planets,
                           uint16_t *nb_spaceships, uint16_t *x_base,
                           uint16_t *y_base) {
   uint16_t count;
-  char *str_scan[MAX_SPLIT_COUNT];
+  char *str_scan[NB_MAX_PLANETS + NB_MAX_SPACESHIPS + 1];
   split(str_scan, response, ',', &count);
   for (uint16_t i = 0; i < count; i++) {
     uint16_t nb_params;
-    char *params[MAX_SPLIT_COUNT];
+    char *params[NB_MAX_PARAMS];
     split(params, str_scan[i], ' ', &nb_params);
     if (params[0][0] == PLANET) {
       parse_planet(params, planets, nb_planets);
@@ -101,5 +101,11 @@ void parse_radar_response(const char *response, Planet *planets,
       *x_base = atoi(params[1]);
       *y_base = atoi(params[2]);
     }
+    for (uint16_t j = 0; j < nb_params; j++) {
+      free(params[j]);
+    }
+  }
+  for (uint16_t i = 0; i < count; i++) {
+    free(str_scan[i]);
   }
 }

--- a/src/embedded/embedded_commands.c
+++ b/src/embedded/embedded_commands.c
@@ -69,10 +69,10 @@ void parse_radar_response_mutex(const char *response, Planet *planets,
                                 uint16_t *nb_planets, Spaceship *spaceships,
                                 uint16_t *nb_spaceships, uint16_t *x_base,
                                 uint16_t *y_base) {
-  get_mutex(planets_spceships_mutex_id);
+  get_mutex(planets_spaceships_mutex_id);
   parse_radar_response(response, planets, nb_planets, spaceships, nb_spaceships,
                        x_base, y_base);
-  release_mutex(planets_spceships_mutex_id);
+  release_mutex(planets_spaceships_mutex_id);
 }
 
 // fonction à call quand vaisseau détruit ou possède une planète

--- a/src/embedded/embedded_commands.c
+++ b/src/embedded/embedded_commands.c
@@ -46,6 +46,12 @@ uint8_t move_v_max(int8_t ship_id, uint16_t angle) {
   return move(ship_id, angle, speed);
 }
 
+uint8_t move_spaceship_to(Spaceship spaceship, uint16_t x, uint16_t y,
+                          uint16_t speed) {
+  uint16_t angle = get_travel_angle(spaceship.x, spaceship.y, x, y);
+  return move(spaceship.ship_id, angle, speed);
+}
+
 uint8_t fire(int8_t ship_id, uint16_t angle) {
   char response[5];
   get_mutex(serial_mutex_id);

--- a/src/embedded/embedded_spaceship.c
+++ b/src/embedded/embedded_spaceship.c
@@ -1,0 +1,33 @@
+#include "embedded_spaceship.h"
+#include "os_utils.h"
+
+void init_embedded_spaceship(Embedded_spaceship *embedded_spaceship,
+                             Spaceship *spaceship, uint8_t index) {
+  embedded_spaceship->spaceship = spaceship;
+  embedded_spaceship->index = index;
+  embedded_spaceship->mutex_id = create_mutex(&spaceships_mutex_attr);
+}
+
+void init_embedded_spaceships(Embedded_spaceship *embedded_spaceships,
+                              Spaceship *spaceships, uint16_t nb_spaceships) {
+  for (uint16_t i = 0; i < nb_spaceships; i++) {
+    init_embedded_spaceship(&embedded_spaceships[i], &spaceships[i], i);
+  }
+}
+
+Spaceship get_spaceship_mutex(Embedded_spaceship *embedded_spaceships,
+                              uint8_t index) {
+  get_mutex(embedded_spaceships[index].mutex_id);
+  Spaceship *spaceship = embedded_spaceships[index].spaceship;
+  release_mutex(embedded_spaceships[index].mutex_id);
+  return *spaceship;
+}
+
+Spaceship update_spaceship_mutex(Spaceship spaceship,
+                                 Embedded_spaceship *embedded_spaceships,
+                                 uint8_t index) {
+  if (osMutexGetOwner(planets_spaceships_mutex_id) != NULL) {
+    return spaceship;
+  }
+  return get_spaceship_mutex(embedded_spaceships, index);
+}

--- a/src/embedded/embedded_spaceship.c
+++ b/src/embedded/embedded_spaceship.c
@@ -22,8 +22,8 @@ Embedded_spaceship *
 get_embedded_spaceship(uint8_t team_id, int8_t ship_id,
                        Embedded_spaceship *embedded_spaceships) {
   for (uint8_t i = 0; i < NB_MAX_SPACESHIPS; i++) {
-    if (embedded_spaceships->spaceship->team_id == team_id &&
-        embedded_spaceships->spaceship->ship_id == ship_id) {
+    if (embedded_spaceships[i].spaceship->team_id == team_id &&
+        embedded_spaceships[i].spaceship->ship_id == ship_id) {
       return &embedded_spaceships[i];
     }
   }

--- a/src/embedded/embedded_spaceship.c
+++ b/src/embedded/embedded_spaceship.c
@@ -10,9 +10,21 @@ void init_embedded_spaceship(Embedded_spaceship *embedded_spaceship,
 
 void init_embedded_spaceships(Embedded_spaceship *embedded_spaceships,
                               Spaceship *spaceships, uint16_t nb_spaceships) {
-  for (uint16_t i = 0; i < nb_spaceships; i++) {
+  for (uint16_t i = 0; i < NB_MAX_SPACESHIPS; i++) {
     init_embedded_spaceship(&embedded_spaceships[i], &spaceships[i], i);
   }
+}
+
+Embedded_spaceship *
+get_embedded_spaceship(uint8_t team_id, int8_t ship_id,
+                       Embedded_spaceship *embedded_spaceships) {
+  for (uint8_t i = 0; i < NB_MAX_SPACESHIPS; i++) {
+    if (embedded_spaceships->spaceship->team_id == team_id &&
+        embedded_spaceships->spaceship->ship_id == ship_id) {
+      return &embedded_spaceships[i];
+    }
+  }
+  return NULL;
 }
 
 Spaceship get_spaceship_mutex(Embedded_spaceship *embedded_spaceships,

--- a/src/embedded/embedded_spaceship.c
+++ b/src/embedded/embedded_spaceship.c
@@ -1,6 +1,9 @@
 #include "embedded_spaceship.h"
 #include "os_utils.h"
 
+const osMutexAttr_t spaceships_mutex_attr = {"spaceshipsMutex",
+                                             osMutexPrioInherit, NULL, 0U};
+
 void init_embedded_spaceship(Embedded_spaceship *embedded_spaceship,
                              Spaceship *spaceship, uint8_t index) {
   embedded_spaceship->spaceship = spaceship;
@@ -9,7 +12,7 @@ void init_embedded_spaceship(Embedded_spaceship *embedded_spaceship,
 }
 
 void init_embedded_spaceships(Embedded_spaceship *embedded_spaceships,
-                              Spaceship *spaceships, uint16_t nb_spaceships) {
+                              Spaceship *spaceships) {
   for (uint16_t i = 0; i < NB_MAX_SPACESHIPS; i++) {
     init_embedded_spaceship(&embedded_spaceships[i], &spaceships[i], i);
   }

--- a/src/main.c
+++ b/src/main.c
@@ -177,7 +177,7 @@ int main(void) {
   const osThreadAttr_t explorersTask_attributes = {
       .name = "explorersTask",
       .priority = (osPriority_t)osPriorityHigh,
-      .stack_size = 2048,
+      .stack_size = 4096,
   };
 
   if ((explorer1TaskHandle = osThreadNew(
@@ -194,7 +194,7 @@ int main(void) {
   const osThreadAttr_t collectorsTask_attributes = {
       .name = "collectorsTask",
       .priority = (osPriority_t)osPriorityAboveNormal,
-      .stack_size = 1024,
+      .stack_size = 512,
   };
   if ((collectorsTaskHandle = osThreadNew(
            collectorsTask, NULL, &collectorsTask_attributes)) == NULL) {
@@ -204,7 +204,7 @@ int main(void) {
   const osThreadAttr_t attackersTask_attributes = {
       .name = "attackersTask",
       .priority = (osPriority_t)osPriorityAboveNormal,
-      .stack_size = 1024,
+      .stack_size = 512,
   };
   if ((attacker1TaskHandle = osThreadNew(
            attackerTask, get_embedded_spaceship(0, 1, embedded_spaceships),

--- a/src/main.c
+++ b/src/main.c
@@ -23,8 +23,11 @@ const osMutexAttr_t serial_mutex_attr = {"serialMutex", osMutexPrioInherit,
                                          NULL, 0U};
 const osMutexAttr_t planets_spaceships_mutex_attr = {
     "planets_spaceshipsMutex", osMutexPrioInherit, NULL, 0U};
+const osMutexAttr_t planets_mutex_attr = {"planetsMutex", osMutexPrioInherit,
+                                          NULL, 0U};
 osMutexId_t serial_mutex_id;
 osMutexId_t planets_spaceships_mutex_id;
+osMutexId_t planets_mutex_id;
 
 uint16_t collector_focus[2][2];
 Planet planets[NB_MAX_PLANETS] = {0};
@@ -146,6 +149,7 @@ int main(void) {
 
   serial_mutex_id = create_mutex(&serial_mutex_attr);
   planets_spaceships_mutex_id = create_mutex(&planets_spaceships_mutex_attr);
+  planets_mutex_id = create_mutex(&planets_mutex_attr);
 #ifdef DEBUG_SERIAL
   while (!push_button_is_pressed()) {
     // Wait for the user to press the button to start the program

--- a/src/main.c
+++ b/src/main.c
@@ -177,7 +177,7 @@ int main(void) {
   const osThreadAttr_t explorersTask_attributes = {
       .name = "explorersTask",
       .priority = (osPriority_t)osPriorityHigh,
-      .stack_size = 4096,
+      .stack_size = 2048,
   };
 
   if ((explorer1TaskHandle = osThreadNew(
@@ -194,7 +194,7 @@ int main(void) {
   const osThreadAttr_t collectorsTask_attributes = {
       .name = "collectorsTask",
       .priority = (osPriority_t)osPriorityAboveNormal,
-      .stack_size = 512,
+      .stack_size = 1024,
   };
   if ((collectorsTaskHandle = osThreadNew(
            collectorsTask, NULL, &collectorsTask_attributes)) == NULL) {
@@ -204,7 +204,7 @@ int main(void) {
   const osThreadAttr_t attackersTask_attributes = {
       .name = "attackersTask",
       .priority = (osPriority_t)osPriorityAboveNormal,
-      .stack_size = 512,
+      .stack_size = 1024,
   };
   if ((attacker1TaskHandle = osThreadNew(
            attackerTask, get_embedded_spaceship(0, 1, embedded_spaceships),

--- a/src/main.c
+++ b/src/main.c
@@ -23,7 +23,7 @@ const osMutexAttr_t serial_mutex_attr = {"serialMutex", osMutexPrioInherit,
 const osMutexAttr_t planets_spceships_mutex_attr = {
     "planets_spceshipsMutex", osMutexPrioInherit, NULL, 0U};
 osMutexId_t serial_mutex_id;
-osMutexId_t planets_spceships_mutex_id;
+osMutexId_t planets_spaceships_mutex_id;
 
 uint16_t collector_focus[2][2];
 Planet planets[NB_MAX_PLANETS];
@@ -124,7 +124,7 @@ int main(void) {
   osKernelInitialize();
 
   serial_mutex_id = create_mutex(&serial_mutex_attr);
-  planets_spceships_mutex_id = create_mutex(&planets_spceships_mutex_attr);
+  planets_spaceships_mutex_id = create_mutex(&planets_spceships_mutex_attr);
 #ifdef DEBUG_SERIAL
   while (!push_button_is_pressed()) {
     // Wait for the user to press the button to start the program
@@ -145,14 +145,14 @@ int main(void) {
       .stack_size = 2048,
   };
 
-  if ((explorer1TaskHandle = osThreadNew(
-           explorerTask, get_spaceship(0, 6, spaceships, nb_spaceships),
-           &explorersTask_attributes)) == NULL) {
+  if ((explorer1TaskHandle =
+           osThreadNew(explorerTask, get_spaceship(0, 6, spaceships),
+                       &explorersTask_attributes)) == NULL) {
     puts("Erreur lors de la création de la tache du premier explorer\n");
   }
-  if ((explorer2TaskHandle = osThreadNew(
-           explorerTask, get_spaceship(0, 7, spaceships, nb_spaceships),
-           &explorersTask_attributes)) == NULL) {
+  if ((explorer2TaskHandle =
+           osThreadNew(explorerTask, get_spaceship(0, 7, spaceships),
+                       &explorersTask_attributes)) == NULL) {
     puts("Erreur lors de la création de la tache du deuxième explorer\n");
   }
   // collectors threads
@@ -171,30 +171,30 @@ int main(void) {
       .priority = (osPriority_t)osPriorityAboveNormal,
       .stack_size = 1024,
   };
-  if ((attacker1TaskHandle = osThreadNew(
-           attackerTask, get_spaceship(0, 1, spaceships, nb_spaceships),
-           &attackersTask_attributes)) == NULL) {
+  if ((attacker1TaskHandle =
+           osThreadNew(attackerTask, get_spaceship(0, 1, spaceships),
+                       &attackersTask_attributes)) == NULL) {
     // Erreur lors de la création de la tache des attaquants\n");
   }
-  if ((attacker2TaskHandle = osThreadNew(
-           attackerTask, get_spaceship(0, 2, spaceships, nb_spaceships),
-           &attackersTask_attributes)) == NULL) {
+  if ((attacker2TaskHandle =
+           osThreadNew(attackerTask, get_spaceship(0, 2, spaceships),
+                       &attackersTask_attributes)) == NULL) {
     // Erreur lors de la création de la tache des attaquants
   }
 
-  if ((baseDefenderTaskHandle = osThreadNew(
-           baseDefenderTask, get_spaceship(0, 3, spaceships, nb_spaceships),
-           &attackersTask_attributes)) == NULL) {
+  if ((baseDefenderTaskHandle =
+           osThreadNew(baseDefenderTask, get_spaceship(0, 3, spaceships),
+                       &attackersTask_attributes)) == NULL) {
     // Erreur lors de la création de la tache du défenseur de base
   }
-  if ((defender1TaskHandle = osThreadNew(
-           defenderTask, get_spaceship(0, 4, spaceships, nb_spaceships),
-           &attackersTask_attributes)) == NULL) {
+  if ((defender1TaskHandle =
+           osThreadNew(defenderTask, get_spaceship(0, 4, spaceships),
+                       &attackersTask_attributes)) == NULL) {
     // Erreur lors de la création de la tache du premier défenseur
   }
-  if ((defender2TaskHandle = osThreadNew(
-           defenderTask, get_spaceship(0, 5, spaceships, nb_spaceships),
-           &attackersTask_attributes)) == NULL) {
+  if ((defender2TaskHandle =
+           osThreadNew(defenderTask, get_spaceship(0, 5, spaceships),
+                       &attackersTask_attributes)) == NULL) {
     // Erreur lors de la création de la tache du deuxième défenseur
   }
 

--- a/src/main.c
+++ b/src/main.c
@@ -48,13 +48,22 @@ void explorerTask(void *argument) {
   Embedded_spaceship *embedded_ship = (Embedded_spaceship *)argument;
   Spaceship explorer =
       get_spaceship_mutex(embedded_spaceships, embedded_ship->index);
+  Embedded_spaceship *embedded_collector;
+  Spaceship collector;
   char radar_response[MAX_RESPONSE_SIZE];
   if (embedded_ship->spaceship->ship_id == 6) {
+    embedded_collector = get_embedded_spaceship(0, 8, embedded_spaceships);
     osDelay(500); // Pour désynchroniser le scan des radars
+  } else {
+    embedded_collector = get_embedded_spaceship(0, 9, embedded_spaceships);
   }
+  collector =
+      get_spaceship_mutex(embedded_spaceships, embedded_collector->index);
   while (1) {
     explorer = update_spaceship_mutex(explorer, embedded_spaceships,
                                       embedded_ship->index);
+    collector = update_spaceship_mutex(collector, embedded_spaceships,
+                                       embedded_collector->index);
     radar(radar_response, explorer.ship_id);
     parse_radar_response_mutex(radar_response, planets, &nb_planets, spaceships,
                                &nb_spaceships, &x_base, &y_base);

--- a/src/main.c
+++ b/src/main.c
@@ -67,6 +67,7 @@ void explorerTask(void *argument) {
     radar(radar_response, explorer.ship_id);
     parse_radar_response_mutex(radar_response, planets, &nb_planets, spaceships,
                                &nb_spaceships, &x_base, &y_base);
+    move_spaceship_to(explorer, collector.x, collector.y, 1000);
     osDelay(5000);
   }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -46,14 +46,15 @@ void explorerTask(void *argument) {
   Spaceship explorer =
       get_spaceship_mutex(embedded_spaceships, embedded_ship->index);
   char radar_response[MAX_RESPONSE_SIZE];
-
+  if (embedded_ship->spaceship->ship_id == 6) {
+    osDelay(500); // Pour désynchroniser le scan des radars
+  }
   while (1) {
     explorer = update_spaceship_mutex(explorer, embedded_spaceships,
                                       embedded_ship->index);
     radar(radar_response, explorer.ship_id);
     parse_radar_response_mutex(radar_response, planets, &nb_planets, spaceships,
                                &nb_spaceships, &x_base, &y_base);
-    // TODO : emit refresh signal for threads
     osDelay(5000);
   }
 }
@@ -138,7 +139,6 @@ void baseDefenderTask(void *argument) {
 }
 
 int main(void) {
-  // les initialisations
   hardware_init();
   push_button_init();
   osKernelInitialize();

--- a/src/main.c
+++ b/src/main.c
@@ -27,10 +27,10 @@ osMutexId_t serial_mutex_id;
 osMutexId_t planets_spaceships_mutex_id;
 
 uint16_t collector_focus[2][2];
-Planet planets[NB_MAX_PLANETS];
+Planet planets[NB_MAX_PLANETS] = {0};
 uint16_t nb_planets = 0;
-Spaceship spaceships[NB_MAX_SPACESHIPS];
-Embedded_spaceship embedded_spaceships[NB_MAX_SPACESHIPS];
+Spaceship spaceships[NB_MAX_SPACESHIPS] = {0};
+Embedded_spaceship embedded_spaceships[NB_MAX_SPACESHIPS] = {0};
 uint16_t nb_spaceships = 0;
 uint16_t x_base = 0;
 uint16_t y_base = 0;

--- a/src/planet.c
+++ b/src/planet.c
@@ -65,6 +65,7 @@ void planet_to_string(char *str, Planet planet) {
           planet.x, planet.y, planet.ship_id, planet.saved);
 }
 void planets_to_string(char *str, Planet *planets) {
+  str[0] = '\0';
   for (uint16_t i = 0; i < NB_MAX_PLANETS; i++) {
     char planet_str[100];
     planet_to_string(planet_str, planets[i]);

--- a/src/planet.c
+++ b/src/planet.c
@@ -15,8 +15,8 @@ void create_planet(uint16_t planet_id, uint16_t x, uint16_t y, int8_t ship_id,
   (*nb_planets)++;
 }
 
-Planet *get_planet(uint16_t planet_id, Planet *planets, uint16_t nb_planets) {
-  for (uint16_t i = 0; i < nb_planets; i++) {
+Planet *get_planet(uint16_t planet_id, Planet *planets) {
+  for (uint16_t i = 0; i < NB_MAX_PLANETS; i++) {
     if (planets[i].planet_id == planet_id) {
       return &planets[i];
     }
@@ -25,8 +25,8 @@ Planet *get_planet(uint16_t planet_id, Planet *planets, uint16_t nb_planets) {
 }
 
 void set_planet(uint16_t planet_id, uint16_t x, uint16_t y, int8_t ship_id,
-                uint8_t saved, Planet *planets, uint16_t nb_planets) {
-  Planet *planet = get_planet(planet_id, planets, nb_planets);
+                uint8_t saved, Planet *planets) {
+  Planet *planet = get_planet(planet_id, planets);
   if (planet == NULL)
     return;
   planet->x = x;
@@ -36,7 +36,7 @@ void set_planet(uint16_t planet_id, uint16_t x, uint16_t y, int8_t ship_id,
 }
 
 void delete_planet(uint16_t planet_id, Planet *planets, uint16_t *nb_planets) {
-  for (uint16_t i = 0; i < *nb_planets; i++) {
+  for (uint16_t i = 0; i < NB_MAX_PLANETS; i++) {
     if (planets[i].planet_id == planet_id) {
       planets[i].planet_id = 0;
       planets[i].x = 0;
@@ -50,7 +50,7 @@ void delete_planet(uint16_t planet_id, Planet *planets, uint16_t *nb_planets) {
 }
 
 void delete_all_planets(Planet *planets, uint16_t *nb_planets) {
-  for (uint16_t i = 0; i < *nb_planets; i++) {
+  for (uint16_t i = 0; i < NB_MAX_PLANETS; i++) {
     planets[i].planet_id = 0;
     planets[i].x = 0;
     planets[i].y = 0;
@@ -64,8 +64,8 @@ void planet_to_string(char *str, Planet planet) {
   sprintf(str, "Planet %d: x=%d, y=%d, ship_id=%d, saved=%d", planet.planet_id,
           planet.x, planet.y, planet.ship_id, planet.saved);
 }
-void planets_to_string(char *str, Planet *planets, uint16_t nb_planets) {
-  for (uint16_t i = 0; i < nb_planets; i++) {
+void planets_to_string(char *str, Planet *planets) {
+  for (uint16_t i = 0; i < NB_MAX_PLANETS; i++) {
     char planet_str[100];
     planet_to_string(planet_str, planets[i]);
     strcat(str, planet_str);

--- a/src/spaceship.c
+++ b/src/spaceship.c
@@ -16,9 +16,9 @@ void create_spaceship(uint8_t team_id, int8_t ship_id, uint16_t x, uint16_t y,
   (*nb_spaceships)++;
 }
 
-Spaceship *get_spaceship(uint8_t team_id, int8_t ship_id, Spaceship *spaceships,
-                         uint16_t nb_spaceships) {
-  for (uint16_t i = 0; i < nb_spaceships; i++) {
+Spaceship *get_spaceship(uint8_t team_id, int8_t ship_id,
+                         Spaceship *spaceships) {
+  for (uint16_t i = 0; i < NB_MAX_SPACESHIPS; i++) {
     if (spaceships[i].team_id == team_id && spaceships[i].ship_id == ship_id) {
       return &spaceships[i];
     }
@@ -27,10 +27,8 @@ Spaceship *get_spaceship(uint8_t team_id, int8_t ship_id, Spaceship *spaceships,
 }
 
 void set_spaceship(uint8_t team_id, int8_t ship_id, uint16_t x, uint16_t y,
-                   uint8_t broken, Spaceship *spaceships,
-                   uint16_t nb_spaceships) {
-  Spaceship *spaceship =
-      get_spaceship(team_id, ship_id, spaceships, nb_spaceships);
+                   uint8_t broken, Spaceship *spaceships) {
+  Spaceship *spaceship = get_spaceship(team_id, ship_id, spaceships);
   if (spaceship == NULL)
     return;
   spaceship->x = x;
@@ -40,7 +38,7 @@ void set_spaceship(uint8_t team_id, int8_t ship_id, uint16_t x, uint16_t y,
 
 void delete_spaceship(uint8_t team_id, int8_t ship_id, Spaceship *spaceships,
                       uint16_t *nb_spaceships) {
-  for (uint16_t i = 0; i < *nb_spaceships; i++) {
+  for (uint16_t i = 0; i < NB_MAX_SPACESHIPS; i++) {
     if (spaceships[i].team_id == team_id && spaceships[i].ship_id == ship_id) {
       spaceships[i].team_id = 0;
       spaceships[i].ship_id = 0;
@@ -54,7 +52,7 @@ void delete_spaceship(uint8_t team_id, int8_t ship_id, Spaceship *spaceships,
 }
 
 void delete_all_spaceships(Spaceship *spaceships, uint16_t *nb_spaceships) {
-  for (uint16_t i = 0; i < *nb_spaceships; i++) {
+  for (uint16_t i = 0; i < NB_MAX_SPACESHIPS; i++) {
     spaceships[i].team_id = 0;
     spaceships[i].ship_id = 0;
     spaceships[i].x = 0;
@@ -69,9 +67,8 @@ void spaceship_to_string(char *str, Spaceship spaceship) {
           spaceship.x, spaceship.y, spaceship.broken);
 }
 
-void spaceships_to_string(char *str, Spaceship *spaceships,
-                          uint16_t nb_spaceships) {
-  for (uint16_t i = 0; i < nb_spaceships; i++) {
+void spaceships_to_string(char *str, Spaceship *spaceships) {
+  for (uint16_t i = 0; i < NB_MAX_SPACESHIPS; i++) {
     char spaceship_str[100];
     spaceship_to_string(spaceship_str, spaceships[i]);
     strcat(str, spaceship_str);

--- a/src/spaceship.c
+++ b/src/spaceship.c
@@ -63,11 +63,13 @@ void delete_all_spaceships(Spaceship *spaceships, uint16_t *nb_spaceships) {
 }
 
 void spaceship_to_string(char *str, Spaceship spaceship) {
-  sprintf(str, "Spaceship %d: x=%d, y=%d, broken=%d", spaceship.ship_id,
-          spaceship.x, spaceship.y, spaceship.broken);
+  sprintf(str, "Spaceship %d: team_id:%d, x=%d, y=%d, broken=%d",
+          spaceship.team_id, spaceship.ship_id, spaceship.x, spaceship.y,
+          spaceship.broken);
 }
 
 void spaceships_to_string(char *str, Spaceship *spaceships) {
+  str[0] = '\0';
   for (uint16_t i = 0; i < NB_MAX_SPACESHIPS; i++) {
     char spaceship_str[100];
     spaceship_to_string(spaceship_str, spaceships[i]);

--- a/test/desktop/test_commands/test_commands.c
+++ b/test/desktop/test_commands/test_commands.c
@@ -50,9 +50,9 @@ void test_split(void) {
 
 void test_parse_radar_response(void) {
   // Arrange
-  Planet planets[NB_MAX_PLANETS];
+  Planet planets[NB_MAX_PLANETS] = {0};
   uint16_t nb_planets = 0;
-  Spaceship spaceships[NB_MAX_SPACESHIPS];
+  Spaceship spaceships[NB_MAX_SPACESHIPS] = {0};
   uint16_t nb_spaceships = 0;
   uint16_t x_base = 0;
   uint16_t y_base = 0;
@@ -67,16 +67,17 @@ void test_parse_radar_response(void) {
   TEST_ASSERT_EQUAL(10000, x_base);
   TEST_ASSERT_EQUAL(2000, y_base);
   for (uint16_t i = 0; i < 5; i++) {
-    TEST_ASSERT_EQUAL(i, planets[i].planet_id);
-    TEST_ASSERT_EQUAL(i + 1, planets[i].x);
-    TEST_ASSERT_EQUAL(i + 2, planets[i].y);
-    TEST_ASSERT_EQUAL(i + 3, planets[i].ship_id);
-    TEST_ASSERT_EQUAL(i % 2, planets[i].saved);
+    TEST_ASSERT_EQUAL(i + 1, planets[i].planet_id);
+    TEST_ASSERT_EQUAL(i + 2, planets[i].x);
+    TEST_ASSERT_EQUAL(i + 3, planets[i].y);
+    TEST_ASSERT_EQUAL(i + 4, planets[i].ship_id);
+    TEST_ASSERT_EQUAL((i + 1) % 2, planets[i].saved);
 
-    TEST_ASSERT_EQUAL(i, spaceships[i].team_id);
-    TEST_ASSERT_EQUAL(i + 1, spaceships[i].ship_id);
-    TEST_ASSERT_EQUAL(i + 2, spaceships[i].x);
-    TEST_ASSERT_EQUAL(i % 2, spaceships[i].broken);
+    TEST_ASSERT_EQUAL(i + 1, spaceships[i].team_id);
+    TEST_ASSERT_EQUAL(i + 2, spaceships[i].ship_id);
+    TEST_ASSERT_EQUAL(i + 3, spaceships[i].x);
+    TEST_ASSERT_EQUAL(i + 4, spaceships[i].y);
+    TEST_ASSERT_EQUAL((i + 1) % 2, spaceships[i].broken);
   }
   delete_all_planets(planets, &nb_planets);
   delete_all_spaceships(spaceships, &nb_spaceships);
@@ -87,7 +88,7 @@ void build_radar_response(char *result) {
   char ship[17];
   char base[8];
   result[0] = '\0';
-  for (uint16_t i = 0; i < 5; i++) {
+  for (uint16_t i = 1; i < 6; i++) {
     build_planet_response(planet, i, i + 1, i + 2, i + 3, i % 2);
     strcat(result, planet);
     strcat(result, ",");

--- a/test/desktop/test_commands/test_commands.c
+++ b/test/desktop/test_commands/test_commands.c
@@ -49,6 +49,9 @@ void test_split(void) {
   TEST_ASSERT_EQUAL_STRING("Theo", tokens[0]);
   TEST_ASSERT_EQUAL_STRING("Louis", tokens[1]);
   TEST_ASSERT_EQUAL_STRING("Pachelle Carelle", tokens[2]);
+  for (uint16_t i = 0; i < count; i++) {
+    free(tokens[i]);
+  }
 }
 
 void test_parse_radar_response(void) {

--- a/test/desktop/test_planet/test_planet.c
+++ b/test/desktop/test_planet/test_planet.c
@@ -37,14 +37,14 @@ void test_create_planet(void) {
 
 void test_get_planet_null(void) {
   // Act
-  Planet *planet = get_planet(638, planets, nb_planets);
+  Planet *planet = get_planet(638, planets);
   // Assert
   TEST_ASSERT_NULL(planet);
 }
 
 void test_get_planet(void) {
   // Act
-  Planet *planet = get_planet(426, planets, nb_planets);
+  Planet *planet = get_planet(426, planets);
   // Assert
   TEST_ASSERT_EQUAL(3, nb_planets);
   TEST_ASSERT_NOT_NULL(planet);
@@ -57,7 +57,7 @@ void test_get_planet(void) {
 
 void test_set_bad_planet(void) {
   // Act
-  set_planet(500, 8000, 10000, 6, 1, planets, nb_planets);
+  set_planet(500, 8000, 10000, 6, 1, planets);
   // Assert
   TEST_ASSERT_EQUAL(3, nb_planets);
   TEST_ASSERT_EQUAL(352, planets[0].planet_id);
@@ -74,7 +74,7 @@ void test_set_bad_planet(void) {
 
 void test_set_planet(void) {
   // Act
-  set_planet(426, 9500, 12000, 2, 1, planets, nb_planets);
+  set_planet(426, 9500, 12000, 2, 1, planets);
   // Assert
   TEST_ASSERT_EQUAL(3, nb_planets);
   TEST_ASSERT_EQUAL(426, planets[1].planet_id);

--- a/test/desktop/test_spaceship/test_spaceship.c
+++ b/test/desktop/test_spaceship/test_spaceship.c
@@ -37,14 +37,14 @@ void test_create_spaceship(void) {
 
 void test_get_spaceship_null(void) {
   // Act
-  Spaceship *spaceship = get_spaceship(5, 1, spaceships, nb_spaceships);
+  Spaceship *spaceship = get_spaceship(5, 1, spaceships);
   // Assert
   TEST_ASSERT_NULL(spaceship);
 }
 
 void test_get_spaceship(void) {
   // Act
-  Spaceship *spaceship = get_spaceship(2, 4, spaceships, nb_spaceships);
+  Spaceship *spaceship = get_spaceship(2, 4, spaceships);
   // Assert
   TEST_ASSERT_EQUAL(3, nb_spaceships);
   TEST_ASSERT_NOT_NULL(spaceship);
@@ -57,9 +57,9 @@ void test_get_spaceship(void) {
 
 void test_set_bad_spaceship(void) {
   // Act
-  set_spaceship(2, 5, 8000, 10000, 1, spaceships, nb_spaceships);
+  set_spaceship(2, 5, 8000, 10000, 1, spaceships);
   // Assert
-  Spaceship *spaceship = get_spaceship(2, 4, spaceships, nb_spaceships);
+  Spaceship *spaceship = get_spaceship(2, 4, spaceships);
   TEST_ASSERT_NOT_NULL(spaceship);
   TEST_ASSERT_EQUAL(9000, spaceship->x);
   TEST_ASSERT_EQUAL(11000, spaceship->y);
@@ -68,9 +68,9 @@ void test_set_bad_spaceship(void) {
 
 void test_set_spaceship(void) {
   // Act
-  set_spaceship(2, 4, 8000, 10000, 1, spaceships, nb_spaceships);
+  set_spaceship(2, 4, 8000, 10000, 1, spaceships);
   // Assert
-  Spaceship *spaceship = get_spaceship(2, 4, spaceships, nb_spaceships);
+  Spaceship *spaceship = get_spaceship(2, 4, spaceships);
   TEST_ASSERT_NOT_NULL(spaceship);
   TEST_ASSERT_EQUAL(8000, spaceship->x);
   TEST_ASSERT_EQUAL(10000, spaceship->y);


### PR DESCRIPTION
Changements : 

- Ajout script pour se connecter au serveur lancé avec serialtcp 
- Ajout des fichiers embedded_spaceships.c/.h pour la déclaration des fonctions utiles à la gestion de l'accès sécurisé aux données des vaisseaux
- Modification des arguments passés en paramètre des threads 
- système d'update dans les boucles while(1) des threads pour actualiser à chaque tour de boucle les données du vaisseau du thread
- correction du parcours des planètes et vaisseaux suite à la modification de type d'enregistrement de la dernière pull-request (utiliser les constantes MAX pour le parcours de toute la liste et pas seulement les n premiers éléments n étant le nombre d'éléments enregistrés dans la liste
- optimisation de l'utilisation des fonctions de planètes et vaisseaux en retirant les paramètres inutiles nb_planets/nb_spaceships
- Fix du parsing de la réponse (free la mémoire allouée par strdup) c'est ok de l'utiliser parce que malloc est threadsafe => maintenant les données se mettent bien à jour.
- Début comportement explorer qui suit le collector attitré -> fonction move_spaceship_to qui prend en paramètre les coordonnées où aller