### PR TITLE
Collector defenders

### DIFF
--- a/include/embedded_commands.h
+++ b/include/embedded_commands.h
@@ -14,7 +14,9 @@ uint8_t move_spaceship_to(Spaceship spaceship, uint16_t x, uint16_t y,
 uint8_t fire(int8_t ship_id, uint16_t angle);
 void radar(char *response, int8_t ship_id);
 
-extern osMutexId_t planets_spaceships_mutex_id;
+extern osMutexId_t spaceships_mutex_id;
+extern osMutexId_t planets_mutex_id;
+
 // parse radar response using mutex
 void parse_radar_response_mutex(const char *response, Planet *planets,
                                 uint16_t *nb_planets, Spaceship *spaceships,

--- a/include/embedded_spaceship.h
+++ b/include/embedded_spaceship.h
@@ -5,7 +5,7 @@
 #include "spaceship.h"
 #include <stdint.h>
 
-extern osMutexId_t planets_spaceships_mutex_id;
+extern osMutexId_t spaceships_mutex_id;
 
 struct Embedded_spaceship_t {
   Spaceship *spaceship;

--- a/include/functionCalculs.h
+++ b/include/functionCalculs.h
@@ -9,6 +9,8 @@
 #define M_PI (3.14159265358979323846)
 #endif
 
+#define NOT_FOUND 404
+
 void determine_target_planets(Spaceship collector1, Spaceship collector2,
                               Planet *planets, uint8_t nb_planets,
                               uint16_t results[2][2]);
@@ -21,7 +23,6 @@ uint16_t get_angle_from_middle(uint16_t x_base, uint16_t y_base);
 uint16_t determine_next_circle_point(uint16_t results[2], uint16_t angle_actuel,
                                      uint8_t direction);
 
-Spaceship *determine_target_spaceship(Spaceship our_ships,
-                                      Spaceship *ennemy_ships,
-                                      uint8_t nb_spaceships);
+uint16_t determine_target_spaceship_angle(Spaceship attacker_ship,
+                                          Spaceship *spaceships);
 #endif // FONCTION_CALCULS_H

--- a/src/embedded/embedded_commands.c
+++ b/src/embedded/embedded_commands.c
@@ -75,10 +75,12 @@ void parse_radar_response_mutex(const char *response, Planet *planets,
                                 uint16_t *nb_planets, Spaceship *spaceships,
                                 uint16_t *nb_spaceships, uint16_t *x_base,
                                 uint16_t *y_base) {
-  get_mutex(planets_spaceships_mutex_id);
+  get_mutex(spaceships_mutex_id);
+  get_mutex(planets_mutex_id);
   parse_radar_response(response, planets, nb_planets, spaceships, nb_spaceships,
                        x_base, y_base);
-  release_mutex(planets_spaceships_mutex_id);
+  release_mutex(planets_mutex_id);
+  release_mutex(spaceships_mutex_id);
 }
 
 // fonction à call quand vaisseau détruit ou possède une planète

--- a/src/embedded/embedded_spaceship.c
+++ b/src/embedded/embedded_spaceship.c
@@ -41,7 +41,7 @@ Spaceship get_spaceship_mutex(Embedded_spaceship *embedded_spaceships,
 Spaceship update_spaceship_mutex(Spaceship spaceship,
                                  Embedded_spaceship *embedded_spaceships,
                                  uint8_t index) {
-  if (osMutexGetOwner(planets_spaceships_mutex_id) != NULL) {
+  if (osMutexGetOwner(spaceships_mutex_id) != NULL) {
     return spaceship;
   }
   return get_spaceship_mutex(embedded_spaceships, index);

--- a/src/functionCalculs.c
+++ b/src/functionCalculs.c
@@ -139,19 +139,18 @@ uint16_t determine_next_circle_point(uint16_t results[2], uint16_t angle_actuel,
   // Récupération de l'angle du prochain point
   return angle_actuel;
 }
-Spaceship *determine_target_spaceship(Spaceship our_ships,
-                                      Spaceship *ennemy_ships,
-                                      uint8_t nb_spaceships) {
+uint16_t determine_target_spaceship_angle(Spaceship attacker_ship,
+                                          Spaceship *spaceships) {
 
-  for (uint8_t i = 0; i < nb_spaceships; i++) {
+  for (uint8_t i = 0; i < NB_MAX_SPACESHIPS; i++) {
 
     uint16_t distance_spaceship = distance_calcul(
-        our_ships.x, our_ships.y, ennemy_ships[i].x, ennemy_ships[i].y);
+        attacker_ship.x, attacker_ship.y, spaceships[i].x, spaceships[i].y);
 
-    // vérifier si la planète est la + proche de collector1
-    if (distance_spaceship < FIRE_RANGE && ennemy_ships[i].team_id != 0) {
-      return &ennemy_ships[i];
+    if (distance_spaceship < FIRE_RANGE && spaceships[i].team_id != 0) {
+      return get_travel_angle(attacker_ship.x, attacker_ship.y, spaceships[i].x,
+                              spaceships[i].y);
     }
   }
-  return NULL;
+  return NOT_FOUND; // 404 Not Found
 }

--- a/src/main.c
+++ b/src/main.c
@@ -61,16 +61,20 @@ void explorerTask(void *argument) {
   collector =
       get_spaceship_mutex(embedded_spaceships, embedded_collector->index);
   while (1) {
+    // update spaceships
     explorer = update_spaceship_mutex(explorer, embedded_spaceships,
                                       embedded_ship->index);
     collector = update_spaceship_mutex(collector, embedded_spaceships,
                                        embedded_collector->index);
+    // if broken go back to base
     if (explorer.broken && !is_returning) {
-      move_spaceship_to(explorer, x_base, y_base, COLLECTORS_MAX_SPEED);
+      move_spaceship_to(explorer, x_base, y_base, EXPLORERS_MAX_SPEED);
       is_returning = 1;
     } else if (!explorer.broken && is_returning) {
       is_returning = 0;
-    } else {
+    }
+    // if not broken do the logic
+    if (!explorer.broken) {
       radar(radar_response, explorer.ship_id);
       parse_radar_response_mutex(radar_response, planets, &nb_planets,
                                  spaceships, &nb_spaceships, &x_base, &y_base);
@@ -96,14 +100,18 @@ void attackerTask(void *argument) {
       get_spaceship_mutex(embedded_spaceships, embedded_ship->index);
   uint8_t is_returning = 0;
   while (1) {
+    // update spaceship
     attacker = update_spaceship_mutex(attacker, embedded_spaceships,
                                       embedded_ship->index);
+    // if broken go back to base
     if (attacker.broken && !is_returning) {
       move_spaceship_to(attacker, x_base, y_base, COLLECTORS_MAX_SPEED);
       is_returning = 1;
     } else if (!attacker.broken && is_returning) {
       is_returning = 0;
-    } else {
+    }
+    // if not broken do the logic
+    if (!attacker.broken) {
       // TODO : implement the attacker logic
     }
     osDelay(1000);
@@ -127,16 +135,20 @@ void defenderTask(void *argument) {
   uint8_t is_returning = 0;
   uint16_t fire_angle = NOT_FOUND;
   while (1) {
+    // update spaceships
     defender = update_spaceship_mutex(defender, embedded_spaceships,
                                       embedded_ship->index);
     collector = update_spaceship_mutex(collector, embedded_spaceships,
                                        embedded_collector->index);
+    // if broken go back to base
     if (defender.broken && !is_returning) {
       move_spaceship_to(defender, x_base, y_base, COLLECTORS_MAX_SPEED);
       is_returning = 1;
     } else if (!defender.broken && is_returning) {
       is_returning = 0;
-    } else {
+    }
+    // if not broken do the logic
+    if (!defender.broken) {
       // follow the collector
       move_spaceship_to(defender, collector.x, collector.y,
                         ATTACKERS_MAX_SPEED);
@@ -212,7 +224,6 @@ void baseDefenderTask(void *argument) {
         state = 0;                          // Revenir à l'état initial
       }
     }
-
     osDelay(1000);
   }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -21,12 +21,12 @@ osThreadId_t defender2TaskHandle;
 
 const osMutexAttr_t serial_mutex_attr = {"serialMutex", osMutexPrioInherit,
                                          NULL, 0U};
-const osMutexAttr_t planets_spaceships_mutex_attr = {
-    "planets_spaceshipsMutex", osMutexPrioInherit, NULL, 0U};
+const osMutexAttr_t spaceships_mutex_attr = {"spaceshipsMutex",
+                                             osMutexPrioInherit, NULL, 0U};
 const osMutexAttr_t planets_mutex_attr = {"planetsMutex", osMutexPrioInherit,
                                           NULL, 0U};
 osMutexId_t serial_mutex_id;
-osMutexId_t planets_spaceships_mutex_id;
+osMutexId_t spaceships_mutex_id;
 osMutexId_t planets_mutex_id;
 
 uint16_t collector_focus[2][2];
@@ -235,7 +235,7 @@ int main(void) {
   init_embedded_spaceships(embedded_spaceships, spaceships);
 
   serial_mutex_id = create_mutex(&serial_mutex_attr);
-  planets_spaceships_mutex_id = create_mutex(&planets_spaceships_mutex_attr);
+  spaceships_mutex_id = create_mutex(&spaceships_mutex_attr);
   planets_mutex_id = create_mutex(&planets_mutex_attr);
 #ifdef DEBUG_SERIAL
   while (!push_button_is_pressed()) {

--- a/test/desktop/test_calculs/test_calculs.c
+++ b/test/desktop/test_calculs/test_calculs.c
@@ -52,19 +52,21 @@ void test_determine_target_planets(void) {
   TEST_ASSERT_EQUAL_INT(
       3, results[1][1]); // Vérifie que le collecteur 2 cible la bonne planète
 }
-void test_determine_target_spaceship(void) {
+void test_determine_target_spaceship_angle(void) {
+  // Arrange
   Spaceship base_defender = {.team_id = 0, .ship_id = 8, .x = 10, .y = 10};
-  Spaceship all_spaceships[] = {
+  Spaceship all_spaceships[NB_MAX_SPACESHIPS] = {
       {.team_id = 0, .ship_id = 8, .x = 10, .y = 10},
       {.team_id = 1, .ship_id = 9, .x = 20, .y = 20},
-      {.team_id = 4, .ship_id = 2, .x = 50, .y = 100}};
-
-  uint8_t nb_spaceships = 2;
-
-  Spaceship *ennemy_ship =
-      determine_target_spaceship(base_defender, all_spaceships, nb_spaceships);
-
-  TEST_ASSERT_EQUAL(&all_spaceships[1], ennemy_ship);
+      {.team_id = 4, .ship_id = 2, .x = 50, .y = 100},
+      {0}};
+  // Act
+  uint16_t angle =
+      determine_target_spaceship_angle(base_defender, all_spaceships);
+  // Assert
+  TEST_ASSERT_EQUAL(get_travel_angle(base_defender.x, base_defender.y,
+                                     all_spaceships[1].x, all_spaceships[1].y),
+                    angle);
 }
 
 void test_get_angle_from_middle(void) {
@@ -102,6 +104,6 @@ int main(void) {
   RUN_TEST(test_determine_target_planets);
   RUN_TEST(test_get_angle_from_middle);
   RUN_TEST(test_determine_next_circle_point);
-  RUN_TEST(test_determine_target_spaceship);
+  RUN_TEST(test_determine_target_spaceship_angle);
   return UNITY_END();
 }


### PR DESCRIPTION
Changements : 
- retourne l'angle au lieu du vaisseau ennemi à cibler sur le fonction get_target_spaceship
- comportement defenders
- protection get_target_spaceship_angle avec mutex
- utiliser un mutex pour la liste des planètes et un mutex pour la liste des vaisseaux au lieu de planète et planète/vaisseau pour protéger seulement les vaisseaux lors du parcours des vaisseaux pour déterminer la cible