### PR TITLE
protect function with mutexes

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -17,5 +17,5 @@ void split(char **tokens, const char *str, const char delimiter,
 void parse_radar_response(const char *response, Planet *planets,
                           uint16_t *nb_planets, Spaceship *spaceships,
                           uint16_t *nb_spaceships, uint16_t *x_base,
-                          uint16_t *y_base);
+                          uint16_t *y_base, uint8_t update_base);
 #endif // COMMANDS_H

--- a/include/embedded_commands.h
+++ b/include/embedded_commands.h
@@ -21,6 +21,6 @@ extern osMutexId_t planets_mutex_id;
 void parse_radar_response_mutex(const char *response, Planet *planets,
                                 uint16_t *nb_planets, Spaceship *spaceships,
                                 uint16_t *nb_spaceships, uint16_t *x_base,
-                                uint16_t *y_base);
+                                uint16_t *y_base, uint8_t update_base);
 
 #endif // EMBEDDED_COMMANDS_H

--- a/include/embedded_function_calcul.h
+++ b/include/embedded_function_calcul.h
@@ -1,0 +1,18 @@
+#ifndef EMBEDDED_FUNCTION_CALCUL_H
+#define EMBEDDED_FUNCTION_CALCUL_H
+
+#include "os_utils.h"
+#include "planet.h"
+#include "spaceship.h"
+#include <stdint.h>
+
+extern osMutexId_t planets_mutex_id;
+extern osMutexId_t spaceships_mutex_id;
+
+void determine_target_planets_mutex(Spaceship collector1, Spaceship collector2,
+                                    Planet *planets, uint8_t nb_planets,
+                                    uint16_t results[2][2]);
+
+uint16_t determine_target_spaceship_angle_mutex(Spaceship attacker_ship,
+                                                Spaceship *spaceships);
+#endif // EMBEDDED_FUNCTION_CALCUL_H

--- a/src/commands.c
+++ b/src/commands.c
@@ -85,7 +85,7 @@ void parse_spaceship(char **params, Spaceship *spaceships,
 void parse_radar_response(const char *response, Planet *planets,
                           uint16_t *nb_planets, Spaceship *spaceships,
                           uint16_t *nb_spaceships, uint16_t *x_base,
-                          uint16_t *y_base) {
+                          uint16_t *y_base, uint8_t update_base) {
   uint16_t count;
   char *str_scan[NB_MAX_PLANETS + NB_MAX_SPACESHIPS + 1];
   split(str_scan, response, ',', &count);
@@ -97,7 +97,7 @@ void parse_radar_response(const char *response, Planet *planets,
       parse_planet(params, planets, nb_planets);
     } else if (params[0][0] == SPACESHIP) {
       parse_spaceship(params, spaceships, nb_spaceships);
-    } else if (params[0][0] == BASE) {
+    } else if (params[0][0] == BASE && update_base) {
       *x_base = atoi(params[1]);
       *y_base = atoi(params[2]);
     }

--- a/src/embedded/embedded_commands.c
+++ b/src/embedded/embedded_commands.c
@@ -74,11 +74,11 @@ void radar(char *response, int8_t ship_id) {
 void parse_radar_response_mutex(const char *response, Planet *planets,
                                 uint16_t *nb_planets, Spaceship *spaceships,
                                 uint16_t *nb_spaceships, uint16_t *x_base,
-                                uint16_t *y_base) {
+                                uint16_t *y_base, uint8_t update_base) {
   get_mutex(spaceships_mutex_id);
   get_mutex(planets_mutex_id);
   parse_radar_response(response, planets, nb_planets, spaceships, nb_spaceships,
-                       x_base, y_base);
+                       x_base, y_base, update_base);
   release_mutex(planets_mutex_id);
   release_mutex(spaceships_mutex_id);
 }

--- a/src/embedded/embedded_function_calcul.c
+++ b/src/embedded/embedded_function_calcul.c
@@ -1,0 +1,19 @@
+#include "embedded_function_calcul.h"
+#include "functionCalculs.h"
+
+void determine_target_planets_mutex(Spaceship collector1, Spaceship collector2,
+                                    Planet *planets, uint8_t nb_planets,
+                                    uint16_t results[2][2]) {
+  get_mutex(planets_mutex_id);
+  determine_target_planets(collector1, collector2, planets, nb_planets,
+                           results);
+  release_mutex(planets_mutex_id);
+}
+
+uint16_t determine_target_spaceship_angle_mutex(Spaceship attacker_ship,
+                                                Spaceship *spaceships) {
+  get_mutex(spaceships_mutex_id);
+  uint16_t angle = determine_target_spaceship_angle(attacker_ship, spaceships);
+  release_mutex(spaceships_mutex_id);
+  return angle;
+}

--- a/src/embedded/embedded_spaceship.c
+++ b/src/embedded/embedded_spaceship.c
@@ -1,14 +1,14 @@
 #include "embedded_spaceship.h"
 #include "os_utils.h"
 
-const osMutexAttr_t spaceships_mutex_attr = {"spaceshipsMutex",
-                                             osMutexPrioInherit, NULL, 0U};
+const osMutexAttr_t ship_mutex_attr = {"shipMutex", osMutexPrioInherit, NULL,
+                                       0U};
 
 void init_embedded_spaceship(Embedded_spaceship *embedded_spaceship,
                              Spaceship *spaceship, uint8_t index) {
   embedded_spaceship->spaceship = spaceship;
   embedded_spaceship->index = index;
-  embedded_spaceship->mutex_id = create_mutex(&spaceships_mutex_attr);
+  embedded_spaceship->mutex_id = create_mutex(&ship_mutex_attr);
 }
 
 void init_embedded_spaceships(Embedded_spaceship *embedded_spaceships,

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #include "main.h"
 #include "embedded_commands.h"
+#include "embedded_function_calcul.h"
 #include "embedded_spaceship.h"
 #include "functionCalculs.h"
 #include "gameConstants.h"
@@ -77,7 +78,8 @@ void explorerTask(void *argument) {
     if (!explorer.broken) {
       radar(radar_response, explorer.ship_id);
       parse_radar_response_mutex(radar_response, planets, &nb_planets,
-                                 spaceships, &nb_spaceships, &x_base, &y_base);
+                                 spaceships, &nb_spaceships, &x_base, &y_base,
+                                 0);
       move_spaceship_to(explorer, collector.x, collector.y,
                         EXPLORERS_MAX_SPEED);
     }
@@ -152,7 +154,7 @@ void defenderTask(void *argument) {
       // follow the collector
       move_spaceship_to(defender, collector.x, collector.y,
                         ATTACKERS_MAX_SPEED);
-      fire_angle = determine_target_spaceship_angle(defender, spaceships);
+      fire_angle = determine_target_spaceship_angle_mutex(defender, spaceships);
       if (fire_angle != NOT_FOUND) {
         fire(defender.ship_id, fire_angle);
       } else {
@@ -175,7 +177,8 @@ void baseDefenderTask(void *argument) {
   while (1) {
     base_defender = update_spaceship_mutex(base_defender, embedded_spaceships,
                                            embedded_ship->index);
-    fire_angle = determine_target_spaceship_angle(base_defender, spaceships);
+    fire_angle =
+        determine_target_spaceship_angle_mutex(base_defender, spaceships);
     if (fire_angle != NOT_FOUND) {
       fire(base_defender.ship_id, fire_angle);
     } else {
@@ -249,7 +252,7 @@ int main(void) {
   char radar_response[MAX_RESPONSE_SIZE];
   radar(radar_response, 6);
   parse_radar_response_mutex(radar_response, planets, &nb_planets, spaceships,
-                             &nb_spaceships, &x_base, &y_base);
+                             &nb_spaceships, &x_base, &y_base, 1);
   // explorers threads
   const osThreadAttr_t explorersTask_attributes = {
       .name = "explorersTask",

--- a/test/desktop/test_commands/test_commands.c
+++ b/test/desktop/test_commands/test_commands.c
@@ -14,7 +14,8 @@ void build_base_response(char *result, uint16_t x, uint16_t y);
 void build_radar_response(char *result);
 void assert_radar_response(Planet *planets, uint16_t nb_planets,
                            Spaceship *spaceships, uint16_t nb_spaceships,
-                           uint16_t x_base, uint16_t y_base);
+                           uint16_t x_base, uint16_t y_base,
+                           uint16_t assert_x_base, uint16_t assert_y_base);
 
 void setUp(void) {
   // set stuff up here
@@ -66,10 +67,10 @@ void test_parse_radar_response(void) {
   build_radar_response(response);
   // Act
   parse_radar_response(response, planets, &nb_planets, spaceships,
-                       &nb_spaceships, &x_base, &y_base);
+                       &nb_spaceships, &x_base, &y_base, 1);
   // Assert
   assert_radar_response(planets, nb_planets, spaceships, nb_spaceships, x_base,
-                        y_base);
+                        y_base, 10000, 2000);
   // cleanup
   delete_all_planets(planets, &nb_planets);
   delete_all_spaceships(spaceships, &nb_spaceships);
@@ -84,16 +85,16 @@ void test_parse_radar_response_update(void) {
   uint16_t x_base = 0;
   uint16_t y_base = 0;
   char response[200] = "P 1 20 30 40 1,P 2 30 40 50 1,S 1 2 30 40 1,S 2 3 40 "
-                       "50 0,B 10000 2000\n";
+                       "50 0,B 0 10000\n";
   parse_radar_response(response, planets, &nb_planets, spaceships,
-                       &nb_spaceships, &x_base, &y_base);
+                       &nb_spaceships, &x_base, &y_base, 1);
   build_radar_response(response);
   // Act
   parse_radar_response(response, planets, &nb_planets, spaceships,
-                       &nb_spaceships, &x_base, &y_base);
+                       &nb_spaceships, &x_base, &y_base, 0);
   // Assert
   assert_radar_response(planets, nb_planets, spaceships, nb_spaceships, x_base,
-                        y_base);
+                        y_base, 0, 10000);
   // cleanup
   delete_all_planets(planets, &nb_planets);
   delete_all_spaceships(spaceships, &nb_spaceships);
@@ -133,11 +134,12 @@ void build_base_response(char *result, uint16_t x, uint16_t y) {
 
 void assert_radar_response(Planet *planets, uint16_t nb_planets,
                            Spaceship *spaceships, uint16_t nb_spaceships,
-                           uint16_t x_base, uint16_t y_base) {
+                           uint16_t x_base, uint16_t y_base,
+                           uint16_t assert_x_base, uint16_t assert_y_base) {
   TEST_ASSERT_EQUAL(5, nb_planets);
   TEST_ASSERT_EQUAL(5, nb_spaceships);
-  TEST_ASSERT_EQUAL(10000, x_base);
-  TEST_ASSERT_EQUAL(2000, y_base);
+  TEST_ASSERT_EQUAL(assert_x_base, x_base);
+  TEST_ASSERT_EQUAL(assert_y_base, y_base);
   for (uint16_t i = 0; i < 5; i++) {
     TEST_ASSERT_EQUAL(i + 1, planets[i].planet_id);
     TEST_ASSERT_EQUAL(i + 2, planets[i].x);


### PR DESCRIPTION
Changements : 
- protéger les appels aux fonctions de functionCalculs avec les mutexes planets et spaceships
- ajout d'un flag sur le parrain pour ne pas update inutilement les coordonnées de la base
- correction de nommage des attributs des mutexes individuels des vaisseaux